### PR TITLE
make mủ a normal predicate

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -8897,12 +8897,12 @@
   {
     "toaq": "mu",
     "type": "predicate",
-    "english": "▯ satisfies property ▯ with the first and second places swapped.",
+    "english": "▯ and ▯ are in relation ▯ with the first and second places swapped.",
     "gloss": "-ed",
     "short": "",
     "keywords": [],
-    "frame": "c 1",
-    "distribution": "d d",
+    "frame": "c c 2",
+    "distribution": "d d d",
     "notes": [],
     "examples": [
       {


### PR DESCRIPTION
Not sure whether this was intentional, but the current definition of *mủ* makes it a pseudo-predicate.