### PR TITLE
Add missing namesake for “c; c 1”

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2778,6 +2778,7 @@
     "keywords": [],
     "frame": "c; c 1",
     "distribution": "d; d d",
+    "namesake": true,
     "notes": [],
     "examples": [],
     "fields": []

--- a/dictionary.json
+++ b/dictionary.json
@@ -2776,9 +2776,8 @@
     "gloss": "free",
     "short": "",
     "keywords": [],
-    "frame": "c; c 1",
+    "frame": "c 1",
     "distribution": "d; d d",
-    "namesake": true,
     "notes": [],
     "examples": [],
     "fields": []


### PR DESCRIPTION
This fixes the error currently visible on https://toaq.net/dictionary/.