### PR TITLE
Add animacy classes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -12,6 +12,7 @@
   {
     "toaq": "afarı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is Africa.",
     "gloss": "Africa",
     "short": "",
@@ -45,6 +46,7 @@
   {
     "toaq": "anı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is sand.",
     "gloss": "sand",
     "short": "",
@@ -58,6 +60,7 @@
   {
     "toaq": "anıguaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a desert.",
     "gloss": "desert",
     "short": "",
@@ -71,6 +74,7 @@
   {
     "toaq": "arane",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a spider.",
     "gloss": "spider",
     "short": "",
@@ -97,6 +101,7 @@
   {
     "toaq": "aqshe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a donkey.",
     "gloss": "donkey",
     "short": "",
@@ -110,6 +115,7 @@
   {
     "toaq": "aq'anı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter A.",
     "gloss": "A",
     "short": "",
@@ -123,6 +129,7 @@
   {
     "toaq": "aq'aq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Q.",
     "gloss": "Q",
     "short": "",
@@ -146,6 +153,7 @@
   {
     "toaq": "aıpu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a ghost/spirit.",
     "gloss": "ghost",
     "short": "",
@@ -159,6 +167,7 @@
   {
     "toaq": "ao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ would be the case if ▯ were the case.",
     "gloss": "would",
     "short": "",
@@ -172,6 +181,7 @@
   {
     "toaq": "aomo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an island.",
     "gloss": "island",
     "short": "",
@@ -255,6 +265,7 @@
   {
     "toaq": "ocha",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a human.",
     "gloss": "human",
     "short": "",
@@ -268,6 +279,7 @@
   {
     "toaq": "ochasıu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is humanoid/human-like.",
     "gloss": "humanoid",
     "short": "",
@@ -281,6 +293,7 @@
   {
     "toaq": "oguı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a snake.",
     "gloss": "snake",
     "short": "",
@@ -294,6 +307,7 @@
   {
     "toaq": "oq'oguı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter O.",
     "gloss": "O",
     "short": "",
@@ -317,6 +331,7 @@
   {
     "toaq": "o'aomo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter '.",
     "gloss": "'",
     "short": "",
@@ -340,6 +355,7 @@
   {
     "toaq": "eku",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an equine/member of genus Equus (the horses, donkeys, and zebras).",
     "gloss": "equine",
     "short": "",
@@ -353,6 +369,7 @@
   {
     "toaq": "elu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an elephant.",
     "gloss": "elephant",
     "short": "",
@@ -376,6 +393,7 @@
   {
     "toaq": "esa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>18</sup> (1,000,000,000,000,000,000) in number; ▯ are a quintillion.",
     "gloss": "exa",
     "short": "",
@@ -389,6 +407,7 @@
   {
     "toaq": "eq'elu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter E.",
     "gloss": "E",
     "short": "",
@@ -402,6 +421,7 @@
   {
     "toaq": "ea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ could be the case if ▯ were the case.",
     "gloss": "could",
     "short": "",
@@ -415,6 +435,7 @@
   {
     "toaq": "eoropa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is Europe.",
     "gloss": "Europe",
     "short": "",
@@ -428,6 +449,7 @@
   {
     "toaq": "yzy",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Y.",
     "gloss": "Y",
     "short": "",
@@ -451,6 +473,7 @@
   {
     "toaq": "batata",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a potato.",
     "gloss": "potato",
     "short": "",
@@ -489,6 +512,7 @@
   {
     "toaq": "baı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ builds/assembles/makes ▯.",
     "gloss": "build",
     "short": "",
@@ -502,6 +526,7 @@
   {
     "toaq": "bao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is white.",
     "gloss": "white",
     "short": "",
@@ -515,6 +540,7 @@
   {
     "toaq": "baoguı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is rice.",
     "gloss": "rice",
     "short": "",
@@ -528,6 +554,7 @@
   {
     "toaq": "bu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is not the case / is false; ▯ does not satisfy property ▯.",
     "gloss": "not",
     "short": "",
@@ -541,6 +568,7 @@
   {
     "toaq": "bubue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter B.",
     "gloss": "B",
     "short": "",
@@ -554,6 +582,7 @@
   {
     "toaq": "bumeraq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a boomerang.",
     "gloss": "boomerang",
     "short": "",
@@ -567,6 +596,7 @@
   {
     "toaq": "buruaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ denies that ▯ is the case.",
     "gloss": "deny",
     "short": "",
@@ -595,6 +625,7 @@
   {
     "toaq": "bu dảı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is impossible.",
     "gloss": "impossible",
     "short": "",
@@ -608,6 +639,7 @@
   {
     "toaq": "bu tỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is away; ▯ is not present at ▯.",
     "gloss": "away",
     "short": "",
@@ -621,6 +653,7 @@
   {
     "toaq": "buq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a mouth.",
     "gloss": "mouth",
     "short": "",
@@ -634,6 +667,7 @@
   {
     "toaq": "buqluao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lip.",
     "gloss": "lip",
     "short": "",
@@ -647,6 +681,7 @@
   {
     "toaq": "bua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ inhabits ▯.",
     "gloss": "inhabit",
     "short": "",
@@ -660,6 +695,7 @@
   {
     "toaq": "buajıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a house (building for living in).",
     "gloss": "house",
     "short": "",
@@ -673,6 +709,7 @@
   {
     "toaq": "buaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ fails to satisfy property ▯.",
     "gloss": "fail",
     "short": "",
@@ -686,6 +723,7 @@
   {
     "toaq": "buaq gảı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ misses ▯; ▯ fails to observe ▯.",
     "gloss": "miss",
     "short": "",
@@ -699,6 +737,7 @@
   {
     "toaq": "buaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is long.",
     "gloss": "long",
     "short": "",
@@ -712,6 +751,7 @@
   {
     "toaq": "buaıtoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a plank.",
     "gloss": "plank",
     "short": "",
@@ -725,6 +765,7 @@
   {
     "toaq": "buı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is outside of ▯.",
     "gloss": "outside",
     "short": "",
@@ -738,6 +779,7 @@
   {
     "toaq": "buıfa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ goes out of / exits ▯.",
     "gloss": "exit",
     "short": "",
@@ -751,6 +793,7 @@
   {
     "toaq": "buo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is ready to satisfy property ▯.",
     "gloss": "ready",
     "short": "",
@@ -764,6 +807,7 @@
   {
     "toaq": "buoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is non-serious.",
     "gloss": "non-serious",
     "short": "",
@@ -777,6 +821,7 @@
   {
     "toaq": "bue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a home of ▯.",
     "gloss": "home",
     "short": "",
@@ -800,6 +845,7 @@
   {
     "toaq": "bıdeo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a video.",
     "gloss": "video",
     "short": "",
@@ -813,6 +859,7 @@
   {
     "toaq": "bıkını",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bikini.",
     "gloss": "bikini",
     "short": "",
@@ -826,6 +873,7 @@
   {
     "toaq": "bıra",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is beer.",
     "gloss": "beer",
     "short": "",
@@ -839,6 +887,7 @@
   {
     "toaq": "bıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are a thousand in number.",
     "gloss": "thousand",
     "short": "",
@@ -852,6 +901,7 @@
   {
     "toaq": "bıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is sick/ill; ▯ is sick/ill with ▯.",
     "gloss": "sick",
     "short": "",
@@ -865,6 +915,7 @@
   {
     "toaq": "bıajıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hospital.",
     "gloss": "hospital",
     "short": "",
@@ -878,6 +929,7 @@
   {
     "toaq": "bıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is enough; ▯ sufficiently satisfies property ▯.",
     "gloss": "enough",
     "short": "",
@@ -891,6 +943,7 @@
   {
     "toaq": "bıao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is confused.",
     "gloss": "confused",
     "short": "",
@@ -904,6 +957,7 @@
   {
     "toaq": "bıu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tube.",
     "gloss": "tube",
     "short": "",
@@ -917,6 +971,7 @@
   {
     "toaq": "bıushoaıcıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a flea.",
     "gloss": "flea",
     "short": "",
@@ -930,6 +985,7 @@
   {
     "toaq": "bıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a cup/glass.",
     "gloss": "cup",
     "short": "",
@@ -943,6 +999,7 @@
   {
     "toaq": "bıe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place after ▯.",
     "gloss": "after",
     "short": "",
@@ -956,6 +1013,7 @@
   {
     "toaq": "bıejao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place long after ▯.",
     "gloss": "long.after",
     "short": "",
@@ -969,6 +1027,7 @@
   {
     "toaq": "bıejuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place shortly after ▯.",
     "gloss": "shortly.after",
     "short": "",
@@ -982,6 +1041,7 @@
   {
     "toaq": "bo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ has/possesses ▯.",
     "gloss": "have",
     "short": "",
@@ -995,6 +1055,7 @@
   {
     "toaq": "bodoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ gives possession of ▯ to ▯.",
     "gloss": "give",
     "short": "",
@@ -1008,6 +1069,7 @@
   {
     "toaq": "bohıaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is poor/unwealthy.",
     "gloss": "poor",
     "short": "",
@@ -1021,6 +1083,7 @@
   {
     "toaq": "bomıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is rich/wealthy.",
     "gloss": "rich",
     "short": "",
@@ -1034,6 +1097,7 @@
   {
     "toaq": "bonua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ takes possession of ▯ from ▯.",
     "gloss": "take",
     "short": "",
@@ -1047,6 +1111,7 @@
   {
     "toaq": "bone",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the amount of ▯'s wealth.",
     "gloss": "wealth",
     "short": "",
@@ -1060,6 +1125,7 @@
   {
     "toaq": "bose",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a wasp.",
     "gloss": "wasp",
     "short": "",
@@ -1073,6 +1139,7 @@
   {
     "toaq": "boq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "That ▯ is the case prevents ▯ from being the case.",
     "gloss": "prevent",
     "short": "",
@@ -1086,6 +1153,7 @@
   {
     "toaq": "boqkıubu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is inevitable.",
     "gloss": "inevitable",
     "short": "",
@@ -1099,6 +1167,7 @@
   {
     "toaq": "boaq",
     "type": "predicate",
+    "animacy": "?",
     "english": "▯ is a shadow; ▯ is a shadow of ▯.",
     "gloss": "shadow",
     "short": "",
@@ -1125,6 +1194,7 @@
   {
     "toaq": "boı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place from ▯ onwards.",
     "gloss": "since",
     "short": "",
@@ -1138,6 +1208,7 @@
   {
     "toaq": "boe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a leaf/sheet.",
     "gloss": "leaf",
     "short": "",
@@ -1151,6 +1222,7 @@
   {
     "toaq": "be",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an infant; ▯ is a baby.",
     "gloss": "infant",
     "short": "",
@@ -1164,6 +1236,7 @@
   {
     "toaq": "bebe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a baby.",
     "gloss": "baby",
     "short": "",
@@ -1177,6 +1250,7 @@
   {
     "toaq": "beq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an extrusion/swelling/convex.",
     "gloss": "extrusion",
     "short": "",
@@ -1190,6 +1264,7 @@
   {
     "toaq": "bea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a knee/elbow/knuckle.",
     "gloss": "hinge.joint",
     "short": "",
@@ -1203,6 +1278,7 @@
   {
     "toaq": "beaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a stick/pole.",
     "gloss": "stick",
     "short": "",
@@ -1226,6 +1302,7 @@
   {
     "toaq": "beo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ changes; ▯ changes in property ▯.",
     "gloss": "change",
     "short": "",
@@ -1239,6 +1316,7 @@
   {
     "toaq": "ca",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ physically causes ▯ to be the case.",
     "gloss": "cause",
     "short": "",
@@ -1253,6 +1331,7 @@
   {
     "toaq": "ca pỏaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ breaks/splits/separates ▯.",
     "gloss": "cause.to.break",
     "short": "",
@@ -1266,6 +1345,7 @@
   {
     "toaq": "caq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ conducts/directs/manages ▯.",
     "gloss": "conduct",
     "short": "",
@@ -1279,6 +1359,7 @@
   {
     "toaq": "caqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a controller (instrument for controlling) for ▯.",
     "gloss": "controller",
     "short": "",
@@ -1292,6 +1373,7 @@
   {
     "toaq": "caqche",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a director/manager/administrator of ▯.",
     "gloss": "director",
     "short": "",
@@ -1305,6 +1387,7 @@
   {
     "toaq": "caqgıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a traffic light.",
     "gloss": "traffic.light",
     "short": "",
@@ -1318,6 +1401,7 @@
   {
     "toaq": "caı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is strong.",
     "gloss": "strong",
     "short": "",
@@ -1331,6 +1415,7 @@
   {
     "toaq": "cao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a season.",
     "gloss": "season",
     "short": "",
@@ -1344,6 +1429,7 @@
   {
     "toaq": "cutao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ spits.",
     "gloss": "spit",
     "short": "",
@@ -1357,6 +1443,7 @@
   {
     "toaq": "cua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ responds to satisfying property ▯ by satisfying property ▯.",
     "gloss": "respond",
     "short": "",
@@ -1371,6 +1458,7 @@
   {
     "toaq": "cuakuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ responds ▯ to ▯.",
     "gloss": "respond",
     "short": "",
@@ -1384,6 +1472,7 @@
   {
     "toaq": "cuaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the concept/idea of satisfying property ▯.",
     "gloss": "concept",
     "short": "",
@@ -1402,6 +1491,7 @@
   {
     "toaq": "cuaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is wet.",
     "gloss": "wet",
     "short": "",
@@ -1415,6 +1505,7 @@
   {
     "toaq": "cuao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is beyond ▯ in property ▯.",
     "gloss": "beyond",
     "short": "",
@@ -1428,6 +1519,7 @@
   {
     "toaq": "cuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is magenta.",
     "gloss": "magenta",
     "short": "",
@@ -1441,6 +1533,7 @@
   {
     "toaq": "cuo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ assumes that ▯ is the case.",
     "gloss": "assume",
     "short": "",
@@ -1454,6 +1547,7 @@
   {
     "toaq": "cue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ reigns over ▯.",
     "gloss": "reign",
     "short": "",
@@ -1467,6 +1561,7 @@
   {
     "toaq": "cuefuaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a government; ▯ is a government of ▯.",
     "gloss": "government",
     "short": "",
@@ -1480,6 +1575,7 @@
   {
     "toaq": "cha",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place in way/form ▯.",
     "gloss": "manner",
     "short": "",
@@ -1493,6 +1589,7 @@
   {
     "toaq": "chaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a day.",
     "gloss": "day",
     "short": "",
@@ -1506,6 +1603,7 @@
   {
     "toaq": "chaqtu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens every day; ▯ is daily.",
     "gloss": "daily",
     "short": "",
@@ -1519,6 +1617,7 @@
   {
     "toaq": "chaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is tea (beverage).",
     "gloss": "tea",
     "short": "",
@@ -1532,6 +1631,7 @@
   {
     "toaq": "chao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a vehicle.",
     "gloss": "vehicle",
     "short": "",
@@ -1545,6 +1645,7 @@
   {
     "toaq": "chaotıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a road/street.",
     "gloss": "road",
     "short": "",
@@ -1558,6 +1659,7 @@
   {
     "toaq": "chu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a middle; ▯ is the middle of ▯.",
     "gloss": "middle",
     "short": "",
@@ -1571,6 +1673,7 @@
   {
     "toaq": "chufaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is ongoing; ▯ is in the middle of taking place; ▯ is ▯-ing.",
     "gloss": "PRG",
     "short": "",
@@ -1584,6 +1687,7 @@
   {
     "toaq": "chuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ eats; ▯ eats ▯.",
     "gloss": "eat",
     "short": "",
@@ -1597,6 +1701,7 @@
   {
     "toaq": "chuqguao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a fork.",
     "gloss": "fork",
     "short": "",
@@ -1610,6 +1715,7 @@
   {
     "toaq": "chuqkuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is hungry.",
     "gloss": "hungry",
     "short": "",
@@ -1623,6 +1729,7 @@
   {
     "toaq": "chuqtıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is edible.",
     "gloss": "edible",
     "short": "",
@@ -1636,6 +1743,7 @@
   {
     "toaq": "chua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a name of ▯.",
     "gloss": "name",
     "short": "",
@@ -1649,6 +1757,7 @@
   {
     "toaq": "chuadoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ names/calls ▯ name ▯.",
     "gloss": "name",
     "short": "",
@@ -1662,6 +1771,7 @@
   {
     "toaq": "chuaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a tendency of behaviour, action, state, condition or opinion belonging to a class or group of persons, or the result of a doctrine, ideology or principle or lack thereof; ▯ is an ideology based on concept ▯; ▯ is an ism; ▯ is an ▯-ism.",
     "gloss": "ism",
     "short": "",
@@ -1675,6 +1785,7 @@
   {
     "toaq": "chuaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is frozen.",
     "gloss": "frozen",
     "short": "",
@@ -1688,6 +1799,7 @@
   {
     "toaq": "chuaıkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a freezer.",
     "gloss": "freezer",
     "short": "",
@@ -1701,6 +1813,7 @@
   {
     "toaq": "chuaınao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is ice (frozen water).",
     "gloss": "ice",
     "short": "",
@@ -1714,6 +1827,7 @@
   {
     "toaq": "chuaıruq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is hail.",
     "gloss": "hail",
     "short": "",
@@ -1732,6 +1846,7 @@
   {
     "toaq": "chuaıruqshua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "It hails; ▯ hails; ▯ hails onto ▯.",
     "gloss": "hail",
     "short": "",
@@ -1750,6 +1865,7 @@
   {
     "toaq": "chuao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a window.",
     "gloss": "window",
     "short": "",
@@ -1763,6 +1879,7 @@
   {
     "toaq": "chuaotıe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a window cover.",
     "gloss": "window cover",
     "short": "",
@@ -1776,6 +1893,7 @@
   {
     "toaq": "chuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is early.",
     "gloss": "early",
     "short": "",
@@ -1789,6 +1907,7 @@
   {
     "toaq": "chuıhaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is breakfast.",
     "gloss": "breakfast",
     "short": "",
@@ -1802,6 +1921,7 @@
   {
     "toaq": "chuırıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is dawn.",
     "gloss": "dawn",
     "short": "",
@@ -1815,6 +1935,7 @@
   {
     "toaq": "chuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tool/utensil/resource/instrument for satisfying property ▯.",
     "gloss": "tool",
     "short": "",
@@ -1828,6 +1949,7 @@
   {
     "toaq": "chue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a train/caravan/succession.",
     "gloss": "train",
     "short": "",
@@ -1841,6 +1963,7 @@
   {
     "toaq": "chuece",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a train station.",
     "gloss": "train.station",
     "short": "",
@@ -1854,6 +1977,7 @@
   {
     "toaq": "chı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ believe ▯ to be the case / to be true.",
     "gloss": "believe",
     "short": "",
@@ -1867,6 +1991,7 @@
   {
     "toaq": "chıchao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Ch.",
     "gloss": "Ch",
     "short": "",
@@ -1880,6 +2005,7 @@
   {
     "toaq": "chıjıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a temple/church/sanctuary/synagogue/shrine.",
     "gloss": "temple",
     "short": "",
@@ -1893,6 +2019,7 @@
   {
     "toaq": "chıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ needs to satisfy property ▯ to satisfy property ▯.",
     "gloss": "need",
     "short": "",
@@ -1906,6 +2033,7 @@
   {
     "toaq": "chıaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is conscious; ▯ is aware of ▯.",
     "gloss": "aware",
     "short": "",
@@ -1919,11 +2047,12 @@
   {
     "toaq": "chıaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is wrong/incorrect.",
     "gloss": "wrong",
     "short": "",
     "keywords": [],
-    "frame": "",
+    "frame": "0",
     "distribution": "d",
     "notes": [],
     "examples": [],
@@ -1932,6 +2061,7 @@
   {
     "toaq": "chıaıtao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ errs; ▯ makes mistake ▯.",
     "gloss": "err",
     "short": "",
@@ -1945,6 +2075,7 @@
   {
     "toaq": "chıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the address/coordinates of ▯.",
     "gloss": "address",
     "short": "",
@@ -1958,6 +2089,7 @@
   {
     "toaq": "chıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ repeats ▯ times.",
     "gloss": "repeat",
     "short": "",
@@ -1971,6 +2103,7 @@
   {
     "toaq": "chıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ learns to satisfy property ▯; ▯ learns how to satisfy property ▯.",
     "gloss": "learn",
     "short": "",
@@ -1984,6 +2117,7 @@
   {
     "toaq": "chıejıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a school.",
     "gloss": "school",
     "short": "",
@@ -1997,6 +2131,7 @@
   {
     "toaq": "chıetua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ teaches ▯ property ▯.",
     "gloss": "teach",
     "short": "",
@@ -2010,6 +2145,7 @@
   {
     "toaq": "chıeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ intersects/crosses/traverses ▯.",
     "gloss": "cross",
     "short": "",
@@ -2023,6 +2159,7 @@
   {
     "toaq": "chıeqfa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ crosses ▯; ▯ goes across ▯.",
     "gloss": "cross",
     "short": "",
@@ -2036,6 +2173,7 @@
   {
     "toaq": "cho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ likes ▯.",
     "gloss": "like",
     "short": "",
@@ -2078,6 +2216,7 @@
   {
     "toaq": "chome",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an insect/bug.",
     "gloss": "insect",
     "short": "",
@@ -2091,6 +2230,7 @@
   {
     "toaq": "chosoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the favourite of ▯ among ▯.",
     "gloss": "favourite",
     "short": "",
@@ -2104,6 +2244,7 @@
   {
     "toaq": "choq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ uses ▯ for ▯.",
     "gloss": "use",
     "short": "",
@@ -2117,6 +2258,7 @@
   {
     "toaq": "choqgı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is useful for doing ▯.",
     "gloss": "useful",
     "short": "",
@@ -2130,6 +2272,7 @@
   {
     "toaq": "choqhuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is useless/inconvenient for doing ▯.",
     "gloss": "useless",
     "short": "",
@@ -2143,6 +2286,7 @@
   {
     "toaq": "choqkıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is usable (possible to use).",
     "gloss": "usable",
     "short": "",
@@ -2156,6 +2300,7 @@
   {
     "toaq": "choqtıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is usable (fit for use).",
     "gloss": "usable",
     "short": "",
@@ -2169,6 +2314,7 @@
   {
     "toaq": "choa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ utters ▯.",
     "gloss": "utter",
     "short": "",
@@ -2182,6 +2328,7 @@
   {
     "toaq": "choakoy",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ talks to ▯.",
     "gloss": "talk",
     "short": "",
@@ -2195,6 +2342,7 @@
   {
     "toaq": "choalaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a voice.",
     "gloss": "voice",
     "short": "",
@@ -2208,6 +2356,7 @@
   {
     "toaq": "choaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a guest; ▯ is a guest of ▯.",
     "gloss": "guest",
     "short": "",
@@ -2221,6 +2370,7 @@
   {
     "toaq": "choaqjıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hotel/guesthouse.",
     "gloss": "hotel",
     "short": "",
@@ -2234,6 +2384,7 @@
   {
     "toaq": "choaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ costs ▯.",
     "gloss": "cost",
     "short": "",
@@ -2247,6 +2398,7 @@
   {
     "toaq": "chou",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an event with ▯ as its instrument.",
     "gloss": "using",
     "short": "",
@@ -2260,6 +2412,7 @@
   {
     "toaq": "choı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is sharp.",
     "gloss": "sharp",
     "short": "",
@@ -2273,6 +2426,7 @@
   {
     "toaq": "choıbeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a thorn.",
     "gloss": "thorn",
     "short": "",
@@ -2286,6 +2440,7 @@
   {
     "toaq": "choıhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a thorn.",
     "gloss": "thorn",
     "short": "",
@@ -2299,6 +2454,7 @@
   {
     "toaq": "choe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ takes place until ▯.",
     "gloss": "until",
     "short": "",
@@ -2312,6 +2468,7 @@
   {
     "toaq": "che",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is someone whose occupation it is to satisfy property ▯.",
     "gloss": "-er",
     "short": "",
@@ -2325,6 +2482,7 @@
   {
     "toaq": "che chỉetua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a teacher.",
     "gloss": "teacher",
     "short": "",
@@ -2338,6 +2496,7 @@
   {
     "toaq": "che gỉaqtao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a musician.",
     "gloss": "musician",
     "short": "",
@@ -2364,6 +2523,7 @@
   {
     "toaq": "chea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hat.",
     "gloss": "hat",
     "short": "",
@@ -2377,6 +2537,7 @@
   {
     "toaq": "chealıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a mushroom.",
     "gloss": "mushroom",
     "short": "",
@@ -2390,6 +2551,7 @@
   {
     "toaq": "cheaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is trusty/trusted to ▯.",
     "gloss": "trusty",
     "short": "",
@@ -2403,6 +2565,7 @@
   {
     "toaq": "cheı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a digit/finger/toe.",
     "gloss": "digit",
     "short": "",
@@ -2416,6 +2579,7 @@
   {
     "toaq": "cheo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are in reciprocal relationship ▯ with each other.",
     "gloss": "reciprocally",
     "short": "",
@@ -2429,6 +2593,7 @@
   {
     "toaq": "cheoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bottle.",
     "gloss": "bottle",
     "short": "",
@@ -2442,6 +2607,7 @@
   {
     "toaq": "cı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are six in number.",
     "gloss": "six",
     "short": "",
@@ -2455,6 +2621,7 @@
   {
     "toaq": "cıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is sixth among ▯.",
     "gloss": "sixth",
     "short": "",
@@ -2468,6 +2635,7 @@
   {
     "toaq": "cıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lacks property ▯.",
     "gloss": "lack",
     "short": "",
@@ -2481,6 +2649,7 @@
   {
     "toaq": "cıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ excretes ▯.",
     "gloss": "excrete",
     "short": "",
@@ -2494,6 +2663,7 @@
   {
     "toaq": "cıurıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a toilet.",
     "gloss": "toilet",
     "short": "",
@@ -2507,6 +2677,7 @@
   {
     "toaq": "cıuse",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an excretion.",
     "gloss": "excretion",
     "short": "",
@@ -2520,6 +2691,7 @@
   {
     "toaq": "cıo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is adolescent/pubescent.",
     "gloss": "adolescent",
     "short": "",
@@ -2533,6 +2705,7 @@
   {
     "toaq": "cıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a fish.",
     "gloss": "fish",
     "short": "",
@@ -2546,6 +2719,7 @@
   {
     "toaq": "coa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bridge.",
     "gloss": "bridge",
     "short": "",
@@ -2559,6 +2733,7 @@
   {
     "toaq": "coaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is tame/domesticated.",
     "gloss": "tamed",
     "short": "",
@@ -2572,6 +2747,7 @@
   {
     "toaq": "coe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is joined/connected to ▯.",
     "gloss": "joined",
     "short": "",
@@ -2585,6 +2761,7 @@
   {
     "toaq": "coetua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ joins ▯ with ▯.",
     "gloss": "join",
     "short": "",
@@ -2598,6 +2775,7 @@
   {
     "toaq": "ce",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a node/station/port.",
     "gloss": "node",
     "short": "",
@@ -2611,6 +2789,7 @@
   {
     "toaq": "cecoa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter C.",
     "gloss": "C",
     "short": "",
@@ -2624,6 +2803,7 @@
   {
     "toaq": "cea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sack/bag/pocket.",
     "gloss": "sack",
     "short": "",
@@ -2637,6 +2817,7 @@
   {
     "toaq": "ceo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ begins/starts to occur; ▯ begins/starts to satisfy property ▯.",
     "gloss": "begin",
     "short": "",
@@ -2680,6 +2861,7 @@
   {
     "toaq": "daragoq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a dragon.",
     "gloss": "dragon",
     "short": "",
@@ -2693,6 +2875,7 @@
   {
     "toaq": "daq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is time.",
     "gloss": "time",
     "short": "",
@@ -2706,6 +2889,7 @@
   {
     "toaq": "daqfaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ occurs frequently/often.",
     "gloss": "frequent",
     "short": "",
@@ -2724,6 +2908,7 @@
   {
     "toaq": "daqfao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the end of ▯; ▯ is the point at which ▯ ceases to be.",
     "gloss": "temporal.end",
     "short": "",
@@ -2737,6 +2922,7 @@
   {
     "toaq": "daqfıa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is previous to ▯ in time.",
     "gloss": "previous",
     "short": "",
@@ -2750,6 +2936,7 @@
   {
     "toaq": "daqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a clock.",
     "gloss": "clock",
     "short": "",
@@ -2763,6 +2950,7 @@
   {
     "toaq": "daqleı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is seldom/infrequent.",
     "gloss": "seldom",
     "short": "",
@@ -2781,6 +2969,7 @@
   {
     "toaq": "daqmıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is eternal/forever.",
     "gloss": "eternal",
     "short": "",
@@ -2794,6 +2983,7 @@
   {
     "toaq": "daqmoa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a moment.",
     "gloss": "moment",
     "short": "",
@@ -2807,6 +2997,7 @@
   {
     "toaq": "daqsheı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ has free time; ▯ has time to satisfy property ▯.",
     "gloss": "free",
     "short": "",
@@ -2820,6 +3011,7 @@
   {
     "toaq": "daqsıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the beginning of ▯; ▯ is the point at which ▯ begins to be.",
     "gloss": "temporal.beginning",
     "short": "",
@@ -2833,6 +3025,7 @@
   {
     "toaq": "daqsıe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is following to ▯ in time.",
     "gloss": "following",
     "short": "",
@@ -2846,6 +3039,7 @@
   {
     "toaq": "daı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is possible; ▯ is possible if ▯ is so.",
     "gloss": "possible",
     "short": "",
@@ -2864,6 +3058,7 @@
   {
     "toaq": "daıchı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ has hope that ▯ is the case; ▯ believes ▯ can happen.",
     "gloss": "hope",
     "short": "",
@@ -2877,6 +3072,7 @@
   {
     "toaq": "daısıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an idea.",
     "gloss": "idea",
     "short": "",
@@ -2890,6 +3086,7 @@
   {
     "toaq": "dao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is information/data.",
     "gloss": "information",
     "short": "",
@@ -2903,6 +3100,7 @@
   {
     "toaq": "daosı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is interested in ▯; ▯ is curious about ▯.",
     "gloss": "interested",
     "short": "",
@@ -2916,6 +3114,7 @@
   {
     "toaq": "du",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ seems to be the case; ▯ seems to satisfy property ▯.",
     "gloss": "seem",
     "short": "",
@@ -2929,6 +3128,7 @@
   {
     "toaq": "dudeo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter D.",
     "gloss": "D",
     "short": "",
@@ -2942,6 +3142,7 @@
   {
     "toaq": "duq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ habitually satisfies property ▯.",
     "gloss": "habitually",
     "short": "",
@@ -2955,6 +3156,7 @@
   {
     "toaq": "dua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ knows ▯ to be the case / to be true.",
     "gloss": "know",
     "short": "",
@@ -2969,6 +3171,7 @@
   {
     "toaq": "duachıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ learns that ▯ is the case.",
     "gloss": "learn",
     "short": "",
@@ -2982,6 +3185,7 @@
   {
     "toaq": "duafuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is obvious; ▯ is obvious to ▯.",
     "gloss": "obvious",
     "short": "",
@@ -3000,6 +3204,7 @@
   {
     "toaq": "duagı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is wise.",
     "gloss": "wise",
     "short": "",
@@ -3013,6 +3218,7 @@
   {
     "toaq": "duahuı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is foolish.",
     "gloss": "foolish",
     "short": "",
@@ -3026,6 +3232,7 @@
   {
     "toaq": "duasue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ wants to know from ▯ fact ▯; ▯ asks ▯ fact ▯.",
     "gloss": "ask",
     "short": "",
@@ -3039,6 +3246,7 @@
   {
     "toaq": "duashao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ wonders about ▯.",
     "gloss": "wonder",
     "short": "",
@@ -3052,6 +3260,7 @@
   {
     "toaq": "duasho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ discovers / finds out ▯.",
     "gloss": "find.out",
     "short": "",
@@ -3065,6 +3274,7 @@
   {
     "toaq": "duaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a larva (distinct juvenile form undergone before metamorphosis into adult form).",
     "gloss": "larva",
     "short": "",
@@ -3078,6 +3288,7 @@
   {
     "toaq": "duaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ must satisfy property ▯.",
     "gloss": "must",
     "short": "",
@@ -3091,6 +3302,7 @@
   {
     "toaq": "duao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is sweet/sugary.",
     "gloss": "sweet",
     "short": "",
@@ -3104,6 +3316,7 @@
   {
     "toaq": "duaohea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a piece of candy.",
     "gloss": "candy",
     "short": "",
@@ -3117,6 +3330,7 @@
   {
     "toaq": "duı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is too much ▯; ▯ satisfies property ▯ too much to satisfy property ▯.",
     "gloss": "too.much",
     "short": "",
@@ -3130,6 +3344,7 @@
   {
     "toaq": "duo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ lasts/continues; ▯ lasts for time ▯.",
     "gloss": "continue",
     "short": "",
@@ -3143,11 +3358,12 @@
   {
     "toaq": "due",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is correct.",
     "gloss": "correct",
     "short": "",
     "keywords": [],
-    "frame": "",
+    "frame": "0",
     "distribution": "d",
     "notes": [],
     "examples": [],
@@ -3156,6 +3372,7 @@
   {
     "toaq": "dueq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a field.",
     "gloss": "field",
     "short": "",
@@ -3169,6 +3386,7 @@
   {
     "toaq": "dı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is allowed to satisfy property ▯.",
     "gloss": "allowed.to",
     "short": "",
@@ -3182,6 +3400,7 @@
   {
     "toaq": "dıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is decreasingly the case; ▯ decreases in how much it satisfies property ▯.",
     "gloss": "decrease",
     "short": "",
@@ -3195,6 +3414,7 @@
   {
     "toaq": "dıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ occurs at regular intervals; ▯ satisfies property ▯ at regular intervals.",
     "gloss": "regular",
     "short": "",
@@ -3208,6 +3428,7 @@
   {
     "toaq": "dıaqkue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a journal/periodical/newspaper.",
     "gloss": "journal",
     "short": "",
@@ -3221,6 +3442,7 @@
   {
     "toaq": "dıaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are seven in number.",
     "gloss": "seven",
     "short": "",
@@ -3234,6 +3456,7 @@
   {
     "toaq": "dıaıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is seventh among ▯.",
     "gloss": "seventh",
     "short": "",
@@ -3247,6 +3470,7 @@
   {
     "toaq": "dıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a drop.",
     "gloss": "drop",
     "short": "",
@@ -3260,6 +3484,7 @@
   {
     "toaq": "dıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the branch of knowledge that studies ▯; ▯ is a science.",
     "gloss": "science",
     "short": "",
@@ -3273,6 +3498,7 @@
   {
     "toaq": "dıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a daytime.",
     "gloss": "daytime",
     "short": "",
@@ -3286,6 +3512,7 @@
   {
     "toaq": "dıochu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a noon.",
     "gloss": "noon",
     "short": "",
@@ -3299,6 +3526,7 @@
   {
     "toaq": "dıochuhaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a lunch.",
     "gloss": "lunch",
     "short": "",
@@ -3312,6 +3540,7 @@
   {
     "toaq": "dıofao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an evening.",
     "gloss": "evening",
     "short": "",
@@ -3325,6 +3554,7 @@
   {
     "toaq": "dıosıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a morning.",
     "gloss": "morning",
     "short": "",
@@ -3338,6 +3568,7 @@
   {
     "toaq": "dıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ suggests ▯.",
     "gloss": "suggest",
     "short": "",
@@ -3351,6 +3582,7 @@
   {
     "toaq": "dıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ sends ▯ to ▯.",
     "gloss": "send",
     "short": "",
@@ -3364,6 +3596,7 @@
   {
     "toaq": "doq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is short.",
     "gloss": "short",
     "short": "",
@@ -3377,6 +3610,7 @@
   {
     "toaq": "doa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ gives property ▯ to ▯.",
     "gloss": "give",
     "short": "",
@@ -3390,6 +3624,7 @@
   {
     "toaq": "doaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a settlement/town/village/city.",
     "gloss": "settlement",
     "short": "",
@@ -3403,6 +3638,7 @@
   {
     "toaq": "doaqpaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a district.",
     "gloss": "district",
     "short": "",
@@ -3416,6 +3652,7 @@
   {
     "toaq": "doı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ respects/venerates/esteems ▯.",
     "gloss": "respect",
     "short": "",
@@ -3459,6 +3696,7 @@
   {
     "toaq": "doe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ functions/performs property ▯.",
     "gloss": "function",
     "short": "",
@@ -3472,6 +3710,7 @@
   {
     "toaq": "de",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is beautiful.",
     "gloss": "beautiful",
     "short": "",
@@ -3485,6 +3724,7 @@
   {
     "toaq": "deq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is able / has the ability to satisfy property ▯.",
     "gloss": "able",
     "short": "",
@@ -3498,6 +3738,7 @@
   {
     "toaq": "dea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hits/punches/kicks ▯.",
     "gloss": "hit",
     "short": "",
@@ -3511,6 +3752,7 @@
   {
     "toaq": "deaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a floor.",
     "gloss": "floor",
     "short": "",
@@ -3524,6 +3766,7 @@
   {
     "toaq": "deaqkoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ crawls.",
     "gloss": "crawl",
     "short": "",
@@ -3537,6 +3780,7 @@
   {
     "toaq": "deaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is worth/deserving of satisfying property ▯.",
     "gloss": "worth",
     "short": "",
@@ -3566,6 +3810,7 @@
   {
     "toaq": "deo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a child.",
     "gloss": "child",
     "short": "",
@@ -3579,6 +3824,7 @@
   {
     "toaq": "fa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ goes to ▯.",
     "gloss": "go",
     "short": "",
@@ -3593,6 +3839,7 @@
   {
     "toaq": "faq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens / takes place.",
     "gloss": "happen",
     "short": "",
@@ -3606,6 +3853,7 @@
   {
     "toaq": "faı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is frequent/common in property ▯; ▯ satisfies frequent/common property ▯.",
     "gloss": "frequent",
     "short": "",
@@ -3619,6 +3867,7 @@
   {
     "toaq": "fao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an end/ending; ▯ is an end/ending of ▯.",
     "gloss": "end",
     "short": "",
@@ -3632,6 +3881,7 @@
   {
     "toaq": "fu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a biological offspring of ▯.",
     "gloss": "offspring",
     "short": "",
@@ -3645,6 +3895,7 @@
   {
     "toaq": "fuq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an article of clothing / garment / dress.",
     "gloss": "clothing",
     "short": "",
@@ -3658,6 +3909,7 @@
   {
     "toaq": "fua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an item of furniture.",
     "gloss": "furniture",
     "short": "",
@@ -3671,6 +3923,7 @@
   {
     "toaq": "fuaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an image / a picture.",
     "gloss": "picture",
     "short": "",
@@ -3684,6 +3937,7 @@
   {
     "toaq": "fuaqkaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ draws image ▯ on ▯.",
     "gloss": "draw",
     "short": "",
@@ -3697,6 +3951,7 @@
   {
     "toaq": "fuaqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a photo-camera.",
     "gloss": "camera",
     "short": "",
@@ -3710,6 +3965,7 @@
   {
     "toaq": "fuaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a committee/board/commission/task force/panel.",
     "gloss": "committee",
     "short": "",
@@ -3725,6 +3981,7 @@
   {
     "toaq": "fuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "Satisfying property ▯ is easy for ▯.",
     "gloss": "easy",
     "short": "",
@@ -3739,6 +3996,7 @@
   {
     "toaq": "fuo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ touches ▯ (non-somatic); ▯ is in contact with ▯.",
     "gloss": "touch",
     "short": "",
@@ -3752,6 +4010,7 @@
   {
     "toaq": "fue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are a hundred in number.",
     "gloss": "hundred",
     "short": "",
@@ -3778,6 +4037,7 @@
   {
     "toaq": "fıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is previous to ▯ in sequence ▯; ▯ precedes ▯ in sequence ▯.",
     "gloss": "previous",
     "short": "",
@@ -3791,6 +4051,7 @@
   {
     "toaq": "fıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is shallow.",
     "gloss": "shallow",
     "short": "",
@@ -3804,6 +4065,7 @@
   {
     "toaq": "fıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ugly.",
     "gloss": "ugly",
     "short": "",
@@ -3817,6 +4079,7 @@
   {
     "toaq": "fıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ creates/invents ▯.",
     "gloss": "create",
     "short": "",
@@ -3830,6 +4093,7 @@
   {
     "toaq": "fofuaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter F.",
     "gloss": "F",
     "short": "",
@@ -3843,6 +4107,7 @@
   {
     "toaq": "foto",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a photograph.",
     "gloss": "photo",
     "short": "",
@@ -3856,6 +4121,7 @@
   {
     "toaq": "foa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ feels ▯ (good or bad); ▯ is ▯ (ill or well).",
     "gloss": "feel",
     "short": "",
@@ -3869,6 +4135,7 @@
   {
     "toaq": "foaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is comfortable; ▯ feels comfort; ▯ feels comfort in satisfying property ▯.",
     "gloss": "comfortable",
     "short": "",
@@ -3882,6 +4149,7 @@
   {
     "toaq": "foaqfuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is convenient; ▯ is comfortably easy.",
     "gloss": "convenient",
     "short": "",
@@ -3896,6 +4164,7 @@
   {
     "toaq": "foı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is bored.",
     "gloss": "bored",
     "short": "",
@@ -3909,6 +4178,7 @@
   {
     "toaq": "fe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are five in number.",
     "gloss": "five",
     "short": "",
@@ -3922,6 +4192,7 @@
   {
     "toaq": "feko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is fifth among ▯.",
     "gloss": "fifth",
     "short": "",
@@ -3935,6 +4206,7 @@
   {
     "toaq": "fea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ endures satisfying property ▯ keeping up property ▯.",
     "gloss": "endure",
     "short": "",
@@ -3962,6 +4234,7 @@
   {
     "toaq": "feı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is angry/mad.",
     "gloss": "angry",
     "short": "",
@@ -3975,6 +4248,7 @@
   {
     "toaq": "feo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a direction.",
     "gloss": "direction",
     "short": "",
@@ -3998,6 +4272,7 @@
   {
     "toaq": "garaq",
     "type": "predicate",
+    "animacy": "?",
     "english": "▯ is a gram.",
     "gloss": "gram",
     "short": "",
@@ -4011,6 +4286,7 @@
   {
     "toaq": "gaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ accompanies / is with ▯ in property ▯.",
     "gloss": "accompany",
     "short": "",
@@ -4024,6 +4300,7 @@
   {
     "toaq": "gaqguru",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a kangaroo.",
     "gloss": "kangaroo",
     "short": "",
@@ -4037,6 +4314,7 @@
   {
     "toaq": "gaqme",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a group/team/gang/band.",
     "gloss": "group",
     "short": "",
@@ -4050,6 +4328,7 @@
   {
     "toaq": "gaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ senses/observes/perceives state of affairs ▯.",
     "gloss": "perceive",
     "short": "",
@@ -4063,6 +4342,7 @@
   {
     "toaq": "gaıpua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ enjoys sensing/observing ▯.",
     "gloss": "enjoy",
     "short": "",
@@ -4076,6 +4356,7 @@
   {
     "toaq": "gao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is above ▯.",
     "gloss": "above",
     "short": "",
@@ -4089,6 +4370,7 @@
   {
     "toaq": "gaokoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ climbs.",
     "gloss": "climb",
     "short": "",
@@ -4102,6 +4384,7 @@
   {
     "toaq": "gaopaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the top of ▯.",
     "gloss": "top",
     "short": "",
@@ -4115,6 +4398,7 @@
   {
     "toaq": "gu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are two in number.",
     "gloss": "two",
     "short": "",
@@ -4128,6 +4412,7 @@
   {
     "toaq": "guchıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens twice / two times.",
     "gloss": "twice",
     "short": "",
@@ -4141,6 +4426,7 @@
   {
     "toaq": "guguı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter G.",
     "gloss": "G",
     "short": "",
@@ -4154,6 +4440,7 @@
   {
     "toaq": "guko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is second among ▯.",
     "gloss": "second",
     "short": "",
@@ -4167,6 +4454,7 @@
   {
     "toaq": "gulıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a pair/couple.",
     "gloss": "pair",
     "short": "",
@@ -4180,6 +4468,7 @@
   {
     "toaq": "gupaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a half.",
     "gloss": "half",
     "short": "",
@@ -4193,6 +4482,7 @@
   {
     "toaq": "gureq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a kidney.",
     "gloss": "kidney",
     "short": "",
@@ -4206,6 +4496,7 @@
   {
     "toaq": "gushoaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a fly.",
     "gloss": "fly",
     "short": "",
@@ -4219,6 +4510,7 @@
   {
     "toaq": "gusıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bicycle/bike.",
     "gloss": "bicycle",
     "short": "",
@@ -4232,6 +4524,7 @@
   {
     "toaq": "guq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is below/underneath ▯.",
     "gloss": "below",
     "short": "",
@@ -4245,6 +4538,7 @@
   {
     "toaq": "guqpaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the bottom of ▯.",
     "gloss": "bottom",
     "short": "",
@@ -4258,6 +4552,7 @@
   {
     "toaq": "gua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a country.",
     "gloss": "country",
     "short": "",
@@ -4271,6 +4566,7 @@
   {
     "toaq": "guaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is land/terrain.",
     "gloss": "land",
     "short": "",
@@ -4284,6 +4580,7 @@
   {
     "toaq": "guaqnao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lake.",
     "gloss": "lake",
     "short": "",
@@ -4297,6 +4594,7 @@
   {
     "toaq": "guaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ works in satisfying property ▯.",
     "gloss": "work",
     "short": "",
@@ -4310,6 +4608,7 @@
   {
     "toaq": "guaırıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a workplace / office.",
     "gloss": "workplace",
     "short": "",
@@ -4323,6 +4622,7 @@
   {
     "toaq": "guao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a furcation/fork/intersection/junction.",
     "gloss": "furcation",
     "short": "",
@@ -4336,6 +4636,7 @@
   {
     "toaq": "guı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is grain/cereal.",
     "gloss": "grain",
     "short": "",
@@ -4349,6 +4650,7 @@
   {
     "toaq": "guıpuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is flour.",
     "gloss": "flour",
     "short": "",
@@ -4362,6 +4664,7 @@
   {
     "toaq": "guo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a repetition/instance of ▯.",
     "gloss": "instance",
     "short": "",
@@ -4375,6 +4678,7 @@
   {
     "toaq": "guobe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a cattle/cow/bull/ox.",
     "gloss": "cattle",
     "short": "",
@@ -4388,6 +4692,7 @@
   {
     "toaq": "guosa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens sometimes.",
     "gloss": "sometimes",
     "short": "",
@@ -4401,6 +4706,7 @@
   {
     "toaq": "guosıa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens never.",
     "gloss": "never",
     "short": "",
@@ -4414,6 +4720,7 @@
   {
     "toaq": "guoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an anus.",
     "gloss": "anus",
     "short": "",
@@ -4427,6 +4734,7 @@
   {
     "toaq": "gue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is curved/bent.",
     "gloss": "curved",
     "short": "",
@@ -4440,6 +4748,7 @@
   {
     "toaq": "gı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is good.",
     "gloss": "good",
     "short": "",
@@ -4466,6 +4775,7 @@
   {
     "toaq": "gıcıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is free of property ▯; ▯ not having property ▯ is good.",
     "gloss": "free.of",
     "short": "",
@@ -4479,6 +4789,7 @@
   {
     "toaq": "gıdaıtue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an opportunity.",
     "gloss": "opportunity",
     "short": "",
@@ -4492,6 +4803,7 @@
   {
     "toaq": "gıga",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>9</sup> (1,000,000,000) in number; ▯ are a billion.",
     "gloss": "giga",
     "short": "",
@@ -4505,6 +4817,7 @@
   {
     "toaq": "gınue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ promises to ▯ to satisfy property ▯, which is good for the latter.",
     "gloss": "promise",
     "short": "",
@@ -4518,6 +4831,7 @@
   {
     "toaq": "gıneq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is fortunate for ▯.",
     "gloss": "fortunate",
     "short": "",
@@ -4531,6 +4845,7 @@
   {
     "toaq": "gıta",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a guitar.",
     "gloss": "guitar",
     "short": "",
@@ -4544,6 +4859,7 @@
   {
     "toaq": "gıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ satisfies with reversed polarity property ▯.",
     "gloss": "opposite",
     "short": "",
@@ -4557,6 +4873,7 @@
   {
     "toaq": "gıq gỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ungood.",
     "gloss": "ungood",
     "short": "",
@@ -4570,6 +4887,7 @@
   {
     "toaq": "gıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a ribbon/tape/strip/stripe.",
     "gloss": "ribbon",
     "short": "",
@@ -4583,6 +4901,7 @@
   {
     "toaq": "gıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is music.",
     "gloss": "music",
     "short": "",
@@ -4596,6 +4915,7 @@
   {
     "toaq": "gıaqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a musical instrument.",
     "gloss": "musical.instrument",
     "short": "",
@@ -4609,6 +4929,7 @@
   {
     "toaq": "gıaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ incises/carves/scratches/engraves/cuts into ▯.",
     "gloss": "incise",
     "short": "",
@@ -4622,6 +4943,7 @@
   {
     "toaq": "gıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is dry.",
     "gloss": "dry",
     "short": "",
@@ -4635,6 +4957,7 @@
   {
     "toaq": "gıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a line.",
     "gloss": "line",
     "short": "",
@@ -4648,6 +4971,7 @@
   {
     "toaq": "gıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is light.",
     "gloss": "light",
     "short": "",
@@ -4661,6 +4985,7 @@
   {
     "toaq": "gıocıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is dark (without light).",
     "gloss": "dark",
     "short": "",
@@ -4674,6 +4999,7 @@
   {
     "toaq": "gıofuaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a photograph.",
     "gloss": "photograph",
     "short": "",
@@ -4687,6 +5013,7 @@
   {
     "toaq": "gıohıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is dark (poorly illuminated).",
     "gloss": "dark",
     "short": "",
@@ -4700,6 +5027,7 @@
   {
     "toaq": "gıokea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lamp.",
     "gloss": "lamp",
     "short": "",
@@ -4713,6 +5041,7 @@
   {
     "toaq": "gıomıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is bright.",
     "gloss": "light",
     "short": "",
@@ -4726,6 +5055,7 @@
   {
     "toaq": "gıe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an arm.",
     "gloss": "arm",
     "short": "",
@@ -4739,6 +5069,7 @@
   {
     "toaq": "gıebea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an elbow.",
     "gloss": "elbow",
     "short": "",
@@ -4752,6 +5083,7 @@
   {
     "toaq": "gıejeoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an armpit.",
     "gloss": "armpit",
     "short": "",
@@ -4765,6 +5097,7 @@
   {
     "toaq": "gıeshıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a shoulder.",
     "gloss": "shoulder",
     "short": "",
@@ -4778,6 +5111,7 @@
   {
     "toaq": "gıeq",
     "type": "predicate",
+    "animacy": "?",
     "english": "▯ shocks ▯.",
     "gloss": "shock",
     "short": "",
@@ -4801,6 +5135,7 @@
   {
     "toaq": "goa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is space/room.",
     "gloss": "space",
     "short": "",
@@ -4814,6 +5149,7 @@
   {
     "toaq": "goafaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is widespread/common.",
     "gloss": "widespread",
     "short": "",
@@ -4827,6 +5163,7 @@
   {
     "toaq": "goajao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is spatially far away from ▯.",
     "gloss": "far",
     "short": "",
@@ -4840,6 +5177,7 @@
   {
     "toaq": "goaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is smooth/even.",
     "gloss": "smooth",
     "short": "",
@@ -4853,6 +5191,7 @@
   {
     "toaq": "goaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ rubs against ▯ (intransitive non-agentive).",
     "gloss": "rub",
     "short": "",
@@ -4866,6 +5205,7 @@
   {
     "toaq": "goaıca",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ causes ▯ to rub against ▯.",
     "gloss": "rub",
     "short": "",
@@ -4880,6 +5220,7 @@
   {
     "toaq": "goaıcheo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ rub against each other.",
     "gloss": "rub.against.each.other",
     "short": "",
@@ -4893,6 +5234,7 @@
   {
     "toaq": "goaıtua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ makes ▯ rub against ▯.",
     "gloss": "rub",
     "short": "",
@@ -4906,6 +5248,7 @@
   {
     "toaq": "goı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ treats/doctors ▯.",
     "gloss": "treat",
     "short": "",
@@ -4919,6 +5262,7 @@
   {
     "toaq": "goe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ will happen in ▯ (amount of time) from now.",
     "gloss": "in",
     "short": "",
@@ -4932,6 +5276,7 @@
   {
     "toaq": "ge",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a stimulus.",
     "gloss": "stimulus",
     "short": "",
@@ -4945,6 +5290,7 @@
   {
     "toaq": "geq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ meets ▯.",
     "gloss": "meet",
     "short": "",
@@ -4958,6 +5304,7 @@
   {
     "toaq": "geqkuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ misses ▯; ▯ hungers to meet ▯ (again).",
     "gloss": "miss",
     "short": "",
@@ -4971,6 +5318,7 @@
   {
     "toaq": "geqsıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is alone.",
     "gloss": "alone",
     "short": "",
@@ -4984,6 +5332,7 @@
   {
     "toaq": "gea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is high.",
     "gloss": "high",
     "short": "",
@@ -4997,6 +5346,7 @@
   {
     "toaq": "geajeaqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lift.",
     "gloss": "lift",
     "short": "",
@@ -5010,6 +5360,7 @@
   {
     "toaq": "geanua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lifts up ▯.",
     "gloss": "lift",
     "short": "",
@@ -5023,6 +5374,7 @@
   {
     "toaq": "geaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is dirty/unclean/contaminated.",
     "gloss": "dirty",
     "short": "",
@@ -5036,6 +5388,7 @@
   {
     "toaq": "geı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ wears ▯.",
     "gloss": "wear",
     "short": "",
@@ -5049,6 +5402,7 @@
   {
     "toaq": "geo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is old.",
     "gloss": "old",
     "short": "",
@@ -5062,6 +5416,7 @@
   {
     "toaq": "geone",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the age of ▯.",
     "gloss": "age",
     "short": "",
@@ -5073,8 +5428,8 @@
     "fields": []
   },
   {
-    "toaq": "ha",
-    "type": "predicate",
+    "toaq": "há",
+    "type": "pronoun",
     "english": "▯ is one/you/they (generic impersonal pronoun).",
     "gloss": "one",
     "short": "",
@@ -5088,6 +5443,7 @@
   {
     "toaq": "hasıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is Asia.",
     "gloss": "Asia",
     "short": "",
@@ -5101,6 +5457,7 @@
   {
     "toaq": "haq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is food.",
     "gloss": "food",
     "short": "",
@@ -5114,6 +5471,7 @@
   {
     "toaq": "haqbaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ prepares food / cooks ▯.",
     "gloss": "prepare.food",
     "short": "",
@@ -5127,6 +5485,7 @@
   {
     "toaq": "haqbaıse",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a meal; ▯ is prepared food.",
     "gloss": "meal",
     "short": "",
@@ -5140,6 +5499,7 @@
   {
     "toaq": "haqdoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ feeds ▯ to ▯.",
     "gloss": "feed",
     "short": "",
@@ -5153,6 +5513,7 @@
   {
     "toaq": "haqhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a stomach.",
     "gloss": "stomach",
     "short": "",
@@ -5166,6 +5527,7 @@
   {
     "toaq": "haqrıaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a plate/dish.",
     "gloss": "plate",
     "short": "",
@@ -5179,6 +5541,7 @@
   {
     "toaq": "haı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is already the case; ▯ already satisfies property ▯.",
     "gloss": "already",
     "short": "",
@@ -5192,6 +5555,7 @@
   {
     "toaq": "hao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "the salient predicate",
     "gloss": "stuff",
     "short": "",
@@ -5216,6 +5580,7 @@
   {
     "toaq": "husho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ becomes quiet/silent; ▯ hushes.",
     "gloss": "hush",
     "short": "",
@@ -5229,6 +5594,7 @@
   {
     "toaq": "Husona",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is US-American/pertains to the USA.",
     "gloss": "American",
     "short": "",
@@ -5242,6 +5608,7 @@
   {
     "toaq": "Husonagua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ are the USA.",
     "gloss": "USA",
     "short": "",
@@ -5255,6 +5622,7 @@
   {
     "toaq": "hua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a body part.",
     "gloss": "body.part",
     "short": "",
@@ -5268,6 +5636,7 @@
   {
     "toaq": "huaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is more the case than ▯; ▯ is more than ▯ in property ▯.",
     "gloss": "more",
     "short": "",
@@ -5282,6 +5651,7 @@
   {
     "toaq": "huaqcho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ prefers ▯ over ▯.",
     "gloss": "prefer",
     "short": "",
@@ -5295,6 +5665,7 @@
   {
     "toaq": "huaq gỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is better than ▯.",
     "gloss": "better",
     "short": "",
@@ -5308,6 +5679,7 @@
   {
     "toaq": "huaq hủı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is worse than ▯.",
     "gloss": "worse",
     "short": "",
@@ -5321,6 +5693,7 @@
   {
     "toaq": "huaq pủı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are more numerous than ▯.",
     "gloss": "more.numerous",
     "short": "",
@@ -5334,6 +5707,7 @@
   {
     "toaq": "huaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ scoops ▯ out of ▯.",
     "gloss": "scoop",
     "short": "",
@@ -5347,6 +5721,7 @@
   {
     "toaq": "huaıchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a spoon.",
     "gloss": "spoon",
     "short": "",
@@ -5360,6 +5735,7 @@
   {
     "toaq": "huao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is loose.",
     "gloss": "loose",
     "short": "",
@@ -5373,6 +5749,7 @@
   {
     "toaq": "huı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is bad.",
     "gloss": "bad",
     "short": "",
@@ -5386,6 +5763,7 @@
   {
     "toaq": "huıcıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is lacking in that does not satisfy property ▯; ▯ lacking property ▯ is bad.",
     "gloss": "lack",
     "short": "",
@@ -5399,6 +5777,7 @@
   {
     "toaq": "huılıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ suffers from experiencing property ▯.",
     "gloss": "suffer",
     "short": "",
@@ -5412,6 +5791,7 @@
   {
     "toaq": "huınue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ threatens ▯ with satisfying property ▯.",
     "gloss": "threaten",
     "short": "",
@@ -5425,6 +5805,7 @@
   {
     "toaq": "huıneq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is unfortunate for ▯.",
     "gloss": "unfortunate",
     "short": "",
@@ -5438,6 +5819,7 @@
   {
     "toaq": "huo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is auditory; ▯ pertains to the sense of hearing/audition.",
     "gloss": "auditory",
     "short": "",
@@ -5451,6 +5833,7 @@
   {
     "toaq": "huogaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hears ▯.",
     "gloss": "hear",
     "short": "",
@@ -5464,6 +5847,7 @@
   {
     "toaq": "huogı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ sounds good; ▯ sounds good to ▯.",
     "gloss": "sound.good",
     "short": "",
@@ -5477,6 +5861,7 @@
   {
     "toaq": "huohua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an ear.",
     "gloss": "ear",
     "short": "",
@@ -5490,6 +5875,7 @@
   {
     "toaq": "huokıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is audible.",
     "gloss": "audible",
     "short": "",
@@ -5503,6 +5889,7 @@
   {
     "toaq": "huokıubu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is inaudible.",
     "gloss": "inaudible",
     "short": "",
@@ -5516,6 +5903,7 @@
   {
     "toaq": "huosı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ listens to ▯.",
     "gloss": "listen",
     "short": "",
@@ -5529,6 +5917,7 @@
   {
     "toaq": "huoı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tail.",
     "gloss": "tail",
     "short": "",
@@ -5542,6 +5931,7 @@
   {
     "toaq": "hue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a feather.",
     "gloss": "feather",
     "short": "",
@@ -5565,6 +5955,7 @@
   {
     "toaq": "hıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is poor in relation ▯; ▯ is in relation ▯ to/with few things.",
     "gloss": "poor",
     "short": "",
@@ -5578,6 +5969,7 @@
   {
     "toaq": "hıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ laughs.",
     "gloss": "laugh",
     "short": "",
@@ -5591,6 +5983,7 @@
   {
     "toaq": "hıaıse",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is laughter.",
     "gloss": "laughter",
     "short": "",
@@ -5604,6 +5997,7 @@
   {
     "toaq": "hıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ harms/injures ▯.",
     "gloss": "harm",
     "short": "",
@@ -5617,6 +6011,7 @@
   {
     "toaq": "hıaodaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is dangerous.",
     "gloss": "dangerous",
     "short": "",
@@ -5630,6 +6025,7 @@
   {
     "toaq": "hıaorıeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ escapes from ▯.",
     "gloss": "escape",
     "short": "",
@@ -5643,6 +6039,7 @@
   {
     "toaq": "hıu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a river.",
     "gloss": "river",
     "short": "",
@@ -5656,6 +6053,7 @@
   {
     "toaq": "hıo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ greets ▯.",
     "gloss": "greet",
     "short": "",
@@ -5674,6 +6072,7 @@
   {
     "toaq": "hıota",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>24</sup> (1,000,000,000,000,000,000,000,000) in number; ▯ are a septillion.",
     "gloss": "yotta",
     "short": "",
@@ -5687,6 +6086,7 @@
   {
     "toaq": "hıoq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is proud / feels pride.",
     "gloss": "proud",
     "short": "",
@@ -5700,6 +6100,7 @@
   {
     "toaq": "hıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ carries/bears/hauls ▯.",
     "gloss": "carry",
     "short": "",
@@ -5726,6 +6127,7 @@
   {
     "toaq": "hora",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an hour.",
     "gloss": "hour",
     "short": "",
@@ -5752,6 +6154,7 @@
   {
     "toaq": "hoqbıe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is afterwards.",
     "gloss": "afterwards",
     "short": "",
@@ -5770,6 +6173,7 @@
   {
     "toaq": "hoqkuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is therefore the case.",
     "gloss": "therefore",
     "short": "",
@@ -5786,8 +6190,8 @@
     "fields": []
   },
   {
-    "toaq": "hoa",
-    "type": "predicate",
+    "toaq": "hóa",
+    "type": "pronoun",
     "english": "relative pronoun whose antecedent is the head of the containing relative clause",
     "gloss": "it",
     "short": "",
@@ -5801,6 +6205,7 @@
   {
     "toaq": "hoaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ burns.",
     "gloss": "burn",
     "short": "",
@@ -5814,6 +6219,7 @@
   {
     "toaq": "hoaqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lighter.",
     "gloss": "lighter",
     "short": "",
@@ -5827,6 +6233,7 @@
   {
     "toaq": "hoaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is still the case; ▯ still satisfies property ▯.",
     "gloss": "still",
     "short": "",
@@ -5850,6 +6257,7 @@
   {
     "toaq": "hoe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sun.",
     "gloss": "sun",
     "short": "",
@@ -5863,6 +6271,7 @@
   {
     "toaq": "he",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is generally the case; ▯ is how things generally are. (gnomic aspect)",
     "gloss": "GNO",
     "short": "",
@@ -5876,6 +6285,7 @@
   {
     "toaq": "hehaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter H.",
     "gloss": "H",
     "short": "",
@@ -5889,6 +6299,7 @@
   {
     "toaq": "heq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ contains ▯.",
     "gloss": "contain",
     "short": "",
@@ -5902,6 +6313,7 @@
   {
     "toaq": "heqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a container.",
     "gloss": "container",
     "short": "",
@@ -5915,6 +6327,7 @@
   {
     "toaq": "heqmuo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is full; ▯ is filled with ▯.",
     "gloss": "full",
     "short": "",
@@ -5928,6 +6341,7 @@
   {
     "toaq": "heqshea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is empty.",
     "gloss": "empty",
     "short": "",
@@ -5941,6 +6355,7 @@
   {
     "toaq": "hea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a piece/chunk; ▯ is a piece/chunk of substance ▯.",
     "gloss": "piece",
     "short": "",
@@ -5954,6 +6369,7 @@
   {
     "toaq": "heaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ carries/holds ▯.",
     "gloss": "carry",
     "short": "",
@@ -5967,6 +6383,7 @@
   {
     "toaq": "heı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are ten in number.",
     "gloss": "ten",
     "short": "",
@@ -5980,6 +6397,7 @@
   {
     "toaq": "heıga",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an oak.",
     "gloss": "oak",
     "short": "",
@@ -5993,6 +6411,7 @@
   {
     "toaq": "heıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is tenth among ▯.",
     "gloss": "tenth",
     "short": "",
@@ -6006,6 +6425,7 @@
   {
     "toaq": "heo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is different from ▯; ▯ differs from ▯ in property ▯.",
     "gloss": "different",
     "short": "",
@@ -6019,6 +6439,7 @@
   {
     "toaq": "heoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a waist.",
     "gloss": "waist",
     "short": "",
@@ -6032,6 +6453,7 @@
   {
     "toaq": "heoqgıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a belt.",
     "gloss": "belt",
     "short": "",
@@ -6065,6 +6487,7 @@
   {
     "toaq": "jake",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a jacket.",
     "gloss": "jacket",
     "short": "",
@@ -6078,6 +6501,7 @@
   {
     "toaq": "jara",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ runs.",
     "gloss": "run",
     "short": "",
@@ -6091,6 +6515,7 @@
   {
     "toaq": "jarafa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a giraffe.",
     "gloss": "giraffe",
     "short": "",
@@ -6104,6 +6529,7 @@
   {
     "toaq": "jaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is very much the case; ▯ is very/extremely ▯.",
     "gloss": "very",
     "short": "",
@@ -6117,6 +6543,7 @@
   {
     "toaq": "jaqbıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is sufficiently the case for ▯ to be the case; ▯ is so much so that ▯ is the case.",
     "gloss": "enough.to",
     "short": "",
@@ -6130,6 +6557,7 @@
   {
     "toaq": "jaqgala",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a jungle.",
     "gloss": "jungle",
     "short": "",
@@ -6143,6 +6571,7 @@
   {
     "toaq": "jaqheo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is not the same amount as ▯ in property ▯.",
     "gloss": "to.different.degree",
     "short": "",
@@ -6156,6 +6585,7 @@
   {
     "toaq": "jaqjeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is as much as ▯ in property ▯.",
     "gloss": "to.same.degree",
     "short": "",
@@ -6169,6 +6599,7 @@
   {
     "toaq": "jaqnuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is tiny.",
     "gloss": "tiny",
     "short": "",
@@ -6182,6 +6613,7 @@
   {
     "toaq": "jaqsao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is huge.",
     "gloss": "huge",
     "short": "",
@@ -6195,6 +6627,7 @@
   {
     "toaq": "jaq bủ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is not at all the case; ▯ does not satisfy property ▯ at all; ▯ very much does not satisfy property ▯.",
     "gloss": "not.at.all",
     "short": "",
@@ -6208,6 +6641,7 @@
   {
     "toaq": "jaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is happy/glad/joyful.",
     "gloss": "happy",
     "short": "",
@@ -6221,6 +6655,7 @@
   {
     "toaq": "jao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is far away from ▯ in property ▯.",
     "gloss": "far",
     "short": "",
@@ -6234,6 +6669,7 @@
   {
     "toaq": "jaokuq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a walkie talkie.",
     "gloss": "walkie.talkie",
     "short": "",
@@ -6247,6 +6683,7 @@
   {
     "toaq": "jaolaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a telephone.",
     "gloss": "phone",
     "short": "",
@@ -6260,6 +6697,7 @@
   {
     "toaq": "jaolaqtao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ talks on the phone with ▯.",
     "gloss": "talk.on.the.phone",
     "short": "",
@@ -6283,6 +6721,7 @@
   {
     "toaq": "jujuo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter J.",
     "gloss": "J",
     "short": "",
@@ -6296,6 +6735,7 @@
   {
     "toaq": "juq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ gets/acquires property ▯.",
     "gloss": "acquire",
     "short": "",
@@ -6309,6 +6749,7 @@
   {
     "toaq": "juqgı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ benefits ▯.",
     "gloss": "benefit",
     "short": "",
@@ -6322,6 +6763,7 @@
   {
     "toaq": "juqkuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ longs for ▯.",
     "gloss": "long.for",
     "short": "",
@@ -6335,6 +6777,7 @@
   {
     "toaq": "jua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is weird/strange/bizarre.",
     "gloss": "weird",
     "short": "",
@@ -6358,6 +6801,7 @@
   {
     "toaq": "juaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is serious/earnest.",
     "gloss": "serious",
     "short": "",
@@ -6371,6 +6815,7 @@
   {
     "toaq": "juao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a rule/law.",
     "gloss": "rule",
     "short": "",
@@ -6384,6 +6829,7 @@
   {
     "toaq": "juaochıaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is illegal; ▯ breaks rule ▯; ▯ is against law ▯.",
     "gloss": "illegal",
     "short": "",
@@ -6397,6 +6843,7 @@
   {
     "toaq": "juaodue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is legal; ▯ is according to rule/law ▯.",
     "gloss": "legal",
     "short": "",
@@ -6410,6 +6857,7 @@
   {
     "toaq": "juı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is near ▯ in property ▯.",
     "gloss": "near",
     "short": "",
@@ -6423,6 +6871,7 @@
   {
     "toaq": "juo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a letter (written message).",
     "gloss": "letter",
     "short": "",
@@ -6436,6 +6885,7 @@
   {
     "toaq": "juoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ should satisfy property ▯.",
     "gloss": "should",
     "short": "",
@@ -6449,6 +6899,7 @@
   {
     "toaq": "juoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ describes ▯ as satisfying property ▯.",
     "gloss": "describe",
     "short": "",
@@ -6471,6 +6922,7 @@
   {
     "toaq": "jue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a month.",
     "gloss": "month",
     "short": "",
@@ -6484,6 +6936,7 @@
   {
     "toaq": "juedıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ occurs monthly.",
     "gloss": "monthly",
     "short": "",
@@ -6510,6 +6963,7 @@
   {
     "toaq": "jıbo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is mine.",
     "gloss": "my",
     "short": "",
@@ -6523,6 +6977,7 @@
   {
     "toaq": "jıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ exists / is real/actual.",
     "gloss": "actual",
     "short": "",
@@ -6536,6 +6991,7 @@
   {
     "toaq": "jıqdua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ knows that ▯ exists.",
     "gloss": "know",
     "short": "",
@@ -6549,6 +7005,7 @@
   {
     "toaq": "jıa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ will happen.",
     "gloss": "FUT",
     "short": "",
@@ -6562,6 +7019,7 @@
   {
     "toaq": "jıachaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is tomorrow; ▯ is the day after today.",
     "gloss": "tomorrow",
     "short": "",
@@ -6575,6 +7033,7 @@
   {
     "toaq": "jıajao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ will happen a long time from now.",
     "gloss": "a.long.time.from.now",
     "short": "",
@@ -6588,6 +7047,7 @@
   {
     "toaq": "jıajuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ will happen in a short time from now.",
     "gloss": "a.short.time.from.now",
     "short": "",
@@ -6601,6 +7061,7 @@
   {
     "toaq": "jıashao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hopes that ▯ will be the case.",
     "gloss": "hope",
     "short": "",
@@ -6614,6 +7075,7 @@
   {
     "toaq": "jıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a world.",
     "gloss": "world",
     "short": "",
@@ -6627,6 +7089,7 @@
   {
     "toaq": "jıaqtu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is the universe.",
     "gloss": "universe",
     "short": "",
@@ -6640,6 +7103,7 @@
   {
     "toaq": "jıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ grasps/holds ▯.",
     "gloss": "grasp",
     "short": "",
@@ -6653,6 +7117,7 @@
   {
     "toaq": "jıaıkoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ climbs.",
     "gloss": "climb",
     "short": "",
@@ -6666,6 +7131,7 @@
   {
     "toaq": "jıaınua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ takes/removes ▯ from ▯.",
     "gloss": "remove",
     "short": "",
@@ -6679,6 +7145,7 @@
   {
     "toaq": "jıao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a god.",
     "gloss": "god",
     "short": "",
@@ -6692,6 +7159,7 @@
   {
     "toaq": "jıaojıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a temple/church/sanctuary/synagogue/shrine.",
     "gloss": "temple",
     "short": "",
@@ -6705,6 +7173,7 @@
   {
     "toaq": "jıu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is born.",
     "gloss": "born",
     "short": "",
@@ -6718,6 +7187,7 @@
   {
     "toaq": "jıuchaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a birthday of ▯.",
     "gloss": "birthday",
     "short": "",
@@ -6731,6 +7201,7 @@
   {
     "toaq": "jıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a building.",
     "gloss": "building",
     "short": "",
@@ -6744,6 +7215,7 @@
   {
     "toaq": "jıoq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ calculates what satisfies property ▯.",
     "gloss": "calculate",
     "short": "",
@@ -6757,6 +7229,7 @@
   {
     "toaq": "jıoqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a computer.",
     "gloss": "computer",
     "short": "",
@@ -6770,6 +7243,7 @@
   {
     "toaq": "jıe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is as ▯ deems/judges/evaluates things to be.",
     "gloss": "deemed",
     "short": "",
@@ -6789,6 +7263,7 @@
   {
     "toaq": "jıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tip / pointed end.",
     "gloss": "tip",
     "short": "",
@@ -6802,6 +7277,7 @@
   {
     "toaq": "jo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are four in number.",
     "gloss": "four",
     "short": "",
@@ -6815,6 +7291,7 @@
   {
     "toaq": "joko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is fourth among ▯.",
     "gloss": "fourth",
     "short": "",
@@ -6828,6 +7305,7 @@
   {
     "toaq": "jolıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a quartet.",
     "gloss": "quartet",
     "short": "",
@@ -6841,6 +7319,7 @@
   {
     "toaq": "joq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is main/chief among ▯.",
     "gloss": "main",
     "short": "",
@@ -6854,6 +7333,7 @@
   {
     "toaq": "joqdoaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a capital city of ▯.",
     "gloss": "capital",
     "short": "",
@@ -6867,6 +7347,7 @@
   {
     "toaq": "joqhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a head (body part).",
     "gloss": "head",
     "short": "",
@@ -6880,6 +7361,7 @@
   {
     "toaq": "joqshaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a face.",
     "gloss": "face",
     "short": "",
@@ -6893,6 +7375,7 @@
   {
     "toaq": "joa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a week.",
     "gloss": "week",
     "short": "",
@@ -6906,6 +7389,7 @@
   {
     "toaq": "joachaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a weekday (day of the week).",
     "gloss": "weekday",
     "short": "",
@@ -6919,6 +7403,7 @@
   {
     "toaq": "joachu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is during the week (not during a weekend).",
     "gloss": "during.the.week",
     "short": "",
@@ -6932,6 +7417,7 @@
   {
     "toaq": "joadıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ occurs weekly.",
     "gloss": "weekly",
     "short": "",
@@ -6945,6 +7431,7 @@
   {
     "toaq": "joafao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a weekend.",
     "gloss": "weekend",
     "short": "",
@@ -6958,6 +7445,7 @@
   {
     "toaq": "joaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a leader of ▯.",
     "gloss": "leader",
     "short": "",
@@ -6971,6 +7459,7 @@
   {
     "toaq": "joaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ looks for ▯",
     "gloss": "seek",
     "short": "",
@@ -6993,6 +7482,7 @@
   {
     "toaq": "joı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is case the case along with ▯; ▯ happens together with ▯.",
     "gloss": "along.with",
     "short": "",
@@ -7006,6 +7496,7 @@
   {
     "toaq": "joe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is skilled at satisfying property ▯.",
     "gloss": "skilled",
     "short": "",
@@ -7019,6 +7510,7 @@
   {
     "toaq": "joetao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ practices skill ▯.",
     "gloss": "practice",
     "short": "",
@@ -7042,6 +7534,7 @@
   {
     "toaq": "Jemu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is Jemu (a legendary whale–moth creature in Toaq mythology).",
     "gloss": "Jemu",
     "short": "",
@@ -7055,6 +7548,7 @@
   {
     "toaq": "jeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is identical to ▯; ▯ is the same as ▯ in property ▯.",
     "gloss": "same",
     "short": "",
@@ -7069,6 +7563,7 @@
   {
     "toaq": "jeqshuaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ copies ▯; ▯ produces an object identical to ▯.",
     "gloss": "copy",
     "short": "",
@@ -7082,6 +7577,7 @@
   {
     "toaq": "jeqtu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is identical to ▯.",
     "gloss": "identical",
     "short": "",
@@ -7095,6 +7591,7 @@
   {
     "toaq": "jea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ makes a purchase; ▯ buys property ▯; ▯ buys property ▯ from ▯.",
     "gloss": "buy",
     "short": "",
@@ -7108,6 +7605,7 @@
   {
     "toaq": "jeajıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a mall.",
     "gloss": "mall",
     "short": "",
@@ -7121,6 +7619,7 @@
   {
     "toaq": "jearıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a market.",
     "gloss": "market",
     "short": "",
@@ -7134,6 +7633,7 @@
   {
     "toaq": "jeaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is increasingly the case; ▯ increases in how much it satisfies property ▯.",
     "gloss": "increase",
     "short": "",
@@ -7147,6 +7647,7 @@
   {
     "toaq": "jeaqcao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a spring (season).",
     "gloss": "spring",
     "short": "",
@@ -7160,6 +7661,7 @@
   {
     "toaq": "jeaqdoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ adds ▯ to ▯.",
     "gloss": "add",
     "short": "",
@@ -7173,6 +7675,7 @@
   {
     "toaq": "jeaq gỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ improves / gets better.",
     "gloss": "improve",
     "short": "",
@@ -7186,6 +7689,7 @@
   {
     "toaq": "jeaq tỉjuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ increases in its proximity to ▯.",
     "gloss": "approach",
     "short": "",
@@ -7212,6 +7716,7 @@
   {
     "toaq": "jeo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is true / is the case; ▯ satisfies property ▯.",
     "gloss": "is.true",
     "short": "",
@@ -7226,6 +7731,7 @@
   {
     "toaq": "jeojuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is almost the case; ▯ almost satisfies property ▯.",
     "gloss": "almost",
     "short": "",
@@ -7239,6 +7745,7 @@
   {
     "toaq": "jeonue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ promises to ▯ that ▯ is the case.",
     "gloss": "promise",
     "short": "",
@@ -7252,6 +7759,7 @@
   {
     "toaq": "jeoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a concave shape; ▯ is a cavity/hollow/cavern.",
     "gloss": "concave",
     "short": "",
@@ -7275,6 +7783,7 @@
   {
     "toaq": "kafe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is coffee.",
     "gloss": "coffee",
     "short": "",
@@ -7288,6 +7797,7 @@
   {
     "toaq": "kaha",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ coughs.",
     "gloss": "cough",
     "short": "",
@@ -7301,6 +7811,7 @@
   {
     "toaq": "kaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is visual/optical; ▯ pertains to the sense of sight/vision.",
     "gloss": "visual",
     "short": "",
@@ -7314,6 +7825,7 @@
   {
     "toaq": "kaqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an optical tool.",
     "gloss": "optical.tool",
     "short": "",
@@ -7327,6 +7839,7 @@
   {
     "toaq": "kaqgaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ sees ▯.",
     "gloss": "see",
     "short": "",
@@ -7340,6 +7853,7 @@
   {
     "toaq": "kaqgı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ looks good; ▯ looks good to ▯.",
     "gloss": "look.good",
     "short": "",
@@ -7353,6 +7867,7 @@
   {
     "toaq": "kaqhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an eye.",
     "gloss": "eye",
     "short": "",
@@ -7366,6 +7881,7 @@
   {
     "toaq": "kaqhuatıe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an eyelid.",
     "gloss": "eyelid",
     "short": "",
@@ -7379,6 +7895,7 @@
   {
     "toaq": "kaqkıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is visible.",
     "gloss": "visible",
     "short": "",
@@ -7392,6 +7909,7 @@
   {
     "toaq": "kaqkıubu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is invisible.",
     "gloss": "invisible",
     "short": "",
@@ -7405,6 +7923,7 @@
   {
     "toaq": "kaqnuo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ dreams ▯.",
     "gloss": "dream",
     "short": "",
@@ -7418,6 +7937,7 @@
   {
     "toaq": "kaqshıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ are glasses.",
     "gloss": "glasses",
     "short": "",
@@ -7431,6 +7951,7 @@
   {
     "toaq": "kaqsı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ looks at / watches ▯.",
     "gloss": "watch",
     "short": "",
@@ -7444,6 +7965,7 @@
   {
     "toaq": "kaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ writes ▯ on ▯.",
     "gloss": "write",
     "short": "",
@@ -7457,6 +7979,7 @@
   {
     "toaq": "kaıfua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a desk.",
     "gloss": "desk",
     "short": "",
@@ -7470,6 +7993,7 @@
   {
     "toaq": "kaıkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a typewriter.",
     "gloss": "typewriter",
     "short": "",
@@ -7483,6 +8007,7 @@
   {
     "toaq": "kaıse",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is text/writing.",
     "gloss": "text",
     "short": "",
@@ -7496,6 +8021,7 @@
   {
     "toaq": "kao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a record of information/data ▯.",
     "gloss": "record",
     "short": "",
@@ -7519,6 +8045,7 @@
   {
     "toaq": "kune",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a member of the genus Canis (the wolves, coyotes, jackals, dingoes, and dogs).",
     "gloss": "dog",
     "short": "",
@@ -7532,6 +8059,7 @@
   {
     "toaq": "kurı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a berry.",
     "gloss": "berry",
     "short": "",
@@ -7545,6 +8073,7 @@
   {
     "toaq": "kuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ says ▯ to ▯.",
     "gloss": "say",
     "short": "",
@@ -7558,6 +8087,7 @@
   {
     "toaq": "kuqnu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is said/alleged to be the case; ▯ allegedly satisfies property ▯.",
     "gloss": "alleged",
     "short": "",
@@ -7571,6 +8101,7 @@
   {
     "toaq": "kuqse",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is text (spoken or written).",
     "gloss": "text",
     "short": "",
@@ -7584,6 +8115,7 @@
   {
     "toaq": "kuqtoaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a sentence.",
     "gloss": "sentence",
     "short": "",
@@ -7597,6 +8129,7 @@
   {
     "toaq": "kua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a room.",
     "gloss": "room",
     "short": "",
@@ -7610,6 +8143,7 @@
   {
     "toaq": "kuabue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an apartment/flat.",
     "gloss": "appartment",
     "short": "",
@@ -7623,6 +8157,7 @@
   {
     "toaq": "kuaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ expresses property ▯.",
     "gloss": "express",
     "short": "",
@@ -7636,6 +8171,7 @@
   {
     "toaq": "kuaq kỉe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ thanks ▯.",
     "gloss": "thank",
     "short": "",
@@ -7654,6 +8190,7 @@
   {
     "toaq": "kuaq shẻo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ apologizes to ▯.",
     "gloss": "",
     "short": "",
@@ -7672,6 +8209,7 @@
   {
     "toaq": "kuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hungers/urges/longs for property ▯.",
     "gloss": "urge.for",
     "short": "",
@@ -7685,6 +8223,7 @@
   {
     "toaq": "kuao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is cyan.",
     "gloss": "cyan",
     "short": "",
@@ -7698,6 +8237,7 @@
   {
     "toaq": "kuaochaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Friday.",
     "gloss": "Friday",
     "short": "",
@@ -7711,6 +8251,7 @@
   {
     "toaq": "kuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the case because ▯.",
     "gloss": "because",
     "short": "",
@@ -7729,6 +8270,7 @@
   {
     "toaq": "kuıtue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a reason why ▯ is the case.",
     "gloss": "reason",
     "short": "",
@@ -7742,6 +8284,7 @@
   {
     "toaq": "kuo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is black.",
     "gloss": "black",
     "short": "",
@@ -7755,6 +8298,7 @@
   {
     "toaq": "kuoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bone.",
     "gloss": "bone",
     "short": "",
@@ -7768,6 +8312,7 @@
   {
     "toaq": "kuoı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is less the case than ▯; ▯ is less than ▯ in property ▯.",
     "gloss": "less",
     "short": "",
@@ -7781,6 +8326,7 @@
   {
     "toaq": "kue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a book.",
     "gloss": "book",
     "short": "",
@@ -7794,6 +8340,7 @@
   {
     "toaq": "kuejıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a library.",
     "gloss": "library",
     "short": "",
@@ -7807,6 +8354,7 @@
   {
     "toaq": "kuepaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a chapter.",
     "gloss": "chapter",
     "short": "",
@@ -7820,6 +8368,7 @@
   {
     "toaq": "kueshuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a library.",
     "gloss": "library",
     "short": "",
@@ -7833,6 +8382,7 @@
   {
     "toaq": "kueq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ (plural) gather/collect at locus ▯ (intransitive and non-agentive).",
     "gloss": "gather",
     "short": "",
@@ -7846,6 +8396,7 @@
   {
     "toaq": "kueqtua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ collects/gathers ▯ (plural) at locus ▯.",
     "gloss": "collect",
     "short": "",
@@ -7892,6 +8443,7 @@
   {
     "toaq": "kıkue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter K.",
     "gloss": "K",
     "short": "",
@@ -7905,6 +8457,7 @@
   {
     "toaq": "kıq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a movie/film.",
     "gloss": "movie",
     "short": "",
@@ -7918,6 +8471,7 @@
   {
     "toaq": "kıqjıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a cinema / movie theater.",
     "gloss": "cinema",
     "short": "",
@@ -7931,6 +8485,7 @@
   {
     "toaq": "kıqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a film camera.",
     "gloss": "camera",
     "short": "",
@@ -7944,6 +8499,7 @@
   {
     "toaq": "kıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is red.",
     "gloss": "red",
     "short": "",
@@ -7957,6 +8513,7 @@
   {
     "toaq": "kıachaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Monday.",
     "gloss": "Monday",
     "short": "",
@@ -7970,6 +8527,7 @@
   {
     "toaq": "kıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hair.",
     "gloss": "hair",
     "short": "",
@@ -7983,6 +8541,7 @@
   {
     "toaq": "kıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ looks after ▯; ▯ takes care of ▯.",
     "gloss": "look.after",
     "short": "",
@@ -7996,6 +8555,7 @@
   {
     "toaq": "kıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a doorway.",
     "gloss": "door",
     "short": "",
@@ -8009,6 +8569,7 @@
   {
     "toaq": "kıaotoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a door.",
     "gloss": "door",
     "short": "",
@@ -8022,6 +8583,7 @@
   {
     "toaq": "kıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ▯able.",
     "gloss": "-able",
     "short": "",
@@ -8045,6 +8607,7 @@
   {
     "toaq": "kıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a ball/sphere.",
     "gloss": "ball",
     "short": "",
@@ -8058,6 +8621,7 @@
   {
     "toaq": "kıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is thankful/grateful to ▯ for satisfying property ▯.",
     "gloss": "thankful",
     "short": "",
@@ -8071,6 +8635,7 @@
   {
     "toaq": "kıekuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ says thanks to ▯.",
     "gloss": "thank",
     "short": "",
@@ -8084,6 +8649,7 @@
   {
     "toaq": "kıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ experiences disgust.",
     "gloss": "disgusted",
     "short": "",
@@ -8097,6 +8663,7 @@
   {
     "toaq": "ko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the xth among ▯ where x is the numerosity of any things satisfying property ▯ sorted by property ▯.",
     "gloss": "nth",
     "short": "",
@@ -8111,6 +8678,7 @@
   {
     "toaq": "kopı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a copy of ▯.",
     "gloss": "copy",
     "short": "",
@@ -8124,6 +8692,7 @@
   {
     "toaq": "kopıshuaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ copies ▯.",
     "gloss": "copy",
     "short": "",
@@ -8137,6 +8706,7 @@
   {
     "toaq": "ko gủ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the second among ▯ sorted by property ▯.",
     "gloss": "second",
     "short": "",
@@ -8150,6 +8720,7 @@
   {
     "toaq": "ko sảq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the third among ▯ sorted by property ▯.",
     "gloss": "third",
     "short": "",
@@ -8163,6 +8734,7 @@
   {
     "toaq": "ko shỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the first among ▯ sorted by property ▯.",
     "gloss": "first",
     "short": "",
@@ -8176,6 +8748,7 @@
   {
     "toaq": "koq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is rough/uneven.",
     "gloss": "rough",
     "short": "",
@@ -8189,6 +8762,7 @@
   {
     "toaq": "koqpıuta",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a computer.",
     "gloss": "computer",
     "short": "",
@@ -8202,6 +8776,7 @@
   {
     "toaq": "koa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is cold/cool.",
     "gloss": "cold",
     "short": "",
@@ -8215,6 +8790,7 @@
   {
     "toaq": "koacao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a winter.",
     "gloss": "winter",
     "short": "",
@@ -8228,6 +8804,7 @@
   {
     "toaq": "koakea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a refrigerator.",
     "gloss": "refrigerator",
     "short": "",
@@ -8241,6 +8818,7 @@
   {
     "toaq": "koaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is mature/ripe/full-grown/adult.",
     "gloss": "mature",
     "short": "",
@@ -8254,6 +8832,7 @@
   {
     "toaq": "koaqlıq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a woman (adult female).",
     "gloss": "woman",
     "short": "",
@@ -8267,6 +8846,7 @@
   {
     "toaq": "koaqnaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a man (adult male).",
     "gloss": "man",
     "short": "",
@@ -8280,6 +8860,7 @@
   {
     "toaq": "koaq'ocha",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an adult human.",
     "gloss": "adult",
     "short": "",
@@ -8293,6 +8874,7 @@
   {
     "toaq": "koaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a net/web/sieve/filter.",
     "gloss": "net",
     "short": "",
@@ -8306,6 +8888,7 @@
   {
     "toaq": "koı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ ambulates (walks/runs/crawls).",
     "gloss": "ambulate",
     "short": "",
@@ -8319,6 +8902,7 @@
   {
     "toaq": "koıtıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a walking path.",
     "gloss": "path",
     "short": "",
@@ -8332,6 +8916,7 @@
   {
     "toaq": "koe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ chooses ▯ out of ▯ for ▯.",
     "gloss": "choose",
     "short": "",
@@ -8346,6 +8931,7 @@
   {
     "toaq": "koemea",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an option.",
     "gloss": "option",
     "short": "",
@@ -8359,6 +8945,7 @@
   {
     "toaq": "koy",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ communicates to ▯ that they (the former) satisfy property ▯.",
     "gloss": "communicate",
     "short": "",
@@ -8382,6 +8969,7 @@
   {
     "toaq": "kebo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a horse (member of species Equus ferus caballus).",
     "gloss": "horse",
     "short": "",
@@ -8395,6 +8983,7 @@
   {
     "toaq": "keq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ are feces; ▯ is excrement/shit/poo.",
     "gloss": "feces",
     "short": "",
@@ -8408,6 +8997,7 @@
   {
     "toaq": "keqcıu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ defecates/shits.",
     "gloss": "defecate",
     "short": "",
@@ -8421,6 +9011,7 @@
   {
     "toaq": "kea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a machine/apparatus performing function ▯.",
     "gloss": "machine",
     "short": "",
@@ -8434,6 +9025,7 @@
   {
     "toaq": "keaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is salty.",
     "gloss": "salty",
     "short": "",
@@ -8447,6 +9039,7 @@
   {
     "toaq": "keaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ has the right to satisfy property ▯.",
     "gloss": "have.right",
     "short": "",
@@ -8484,6 +9077,7 @@
   {
     "toaq": "keıcıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a degree Celsius.",
     "gloss": "Celsius",
     "short": "",
@@ -8527,6 +9121,7 @@
   {
     "toaq": "labı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a lion.",
     "gloss": "lion",
     "short": "",
@@ -8540,6 +9135,7 @@
   {
     "toaq": "laq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a sound; ▯ is audio.",
     "gloss": "sound",
     "short": "",
@@ -8553,6 +9149,7 @@
   {
     "toaq": "laqcaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is loud.",
     "gloss": "loud",
     "short": "",
@@ -8566,6 +9163,7 @@
   {
     "toaq": "laqgıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an audio tape.",
     "gloss": "tape",
     "short": "",
@@ -8579,6 +9177,7 @@
   {
     "toaq": "laqkue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an audiobook.",
     "gloss": "audiobook",
     "short": "",
@@ -8592,6 +9191,7 @@
   {
     "toaq": "laqrue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a weak/low sound.",
     "gloss": "low",
     "short": "",
@@ -8605,6 +9205,7 @@
   {
     "toaq": "laı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a letter/glyph/sign/character/symbol/graphical component signifying ▯.",
     "gloss": "letter",
     "short": "",
@@ -8618,6 +9219,7 @@
   {
     "toaq": "lao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ waits for ▯ to be the case.",
     "gloss": "wait",
     "short": "",
@@ -8631,6 +9233,7 @@
   {
     "toaq": "laolıq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter L.",
     "gloss": "L",
     "short": "",
@@ -8654,6 +9257,7 @@
   {
     "toaq": "luq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is calm/silent.",
     "gloss": "calm",
     "short": "",
@@ -8667,6 +9271,7 @@
   {
     "toaq": "luqmoe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is calm (emotionally).",
     "gloss": "calm",
     "short": "",
@@ -8680,6 +9285,7 @@
   {
     "toaq": "lua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a story.",
     "gloss": "story",
     "short": "",
@@ -8693,6 +9299,7 @@
   {
     "toaq": "luaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ plays / has fun with / uses for entertainment ▯.",
     "gloss": "play",
     "short": "",
@@ -8706,6 +9313,7 @@
   {
     "toaq": "luaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is funny/comical.",
     "gloss": "funny",
     "short": "",
@@ -8719,6 +9327,7 @@
   {
     "toaq": "luaılua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a joke.",
     "gloss": "joke",
     "short": "",
@@ -8732,6 +9341,7 @@
   {
     "toaq": "luao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lip (general sense).",
     "gloss": "lip",
     "short": "",
@@ -8747,6 +9357,7 @@
   {
     "toaq": "luı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ has taken place.",
     "gloss": "PRF",
     "short": "",
@@ -8760,6 +9371,7 @@
   {
     "toaq": "luıne",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the age of ▯; ▯ is the time since ▯ has taken place.",
     "gloss": "age",
     "short": "",
@@ -8773,6 +9385,7 @@
   {
     "toaq": "luo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a family.",
     "gloss": "family",
     "short": "",
@@ -8786,6 +9399,7 @@
   {
     "toaq": "luoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is in balance with ▯.",
     "gloss": "balanced",
     "short": "",
@@ -8799,6 +9413,7 @@
   {
     "toaq": "lue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is yellow.",
     "gloss": "yellow",
     "short": "",
@@ -8812,6 +9427,7 @@
   {
     "toaq": "luechaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Wednesday.",
     "gloss": "wednesday",
     "short": "",
@@ -8825,6 +9441,7 @@
   {
     "toaq": "lueq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ serves ▯ with property ▯.",
     "gloss": "serve",
     "short": "",
@@ -8838,6 +9455,7 @@
   {
     "toaq": "lueqche",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a servant of ▯ with property ▯.",
     "gloss": "servant",
     "short": "",
@@ -8851,6 +9469,7 @@
   {
     "toaq": "lıq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is female.",
     "gloss": "female",
     "short": "",
@@ -8864,6 +9483,7 @@
   {
     "toaq": "lıqdeo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a girl.",
     "gloss": "girl",
     "short": "",
@@ -8877,6 +9497,7 @@
   {
     "toaq": "lıqfu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a daughter (female biological offspring) of ▯.",
     "gloss": "daughter",
     "short": "",
@@ -8890,6 +9511,7 @@
   {
     "toaq": "lıqpao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a mother of ▯; ▯ acts as a mother towards ▯.",
     "gloss": "mother",
     "short": "",
@@ -8903,6 +9525,7 @@
   {
     "toaq": "lıqpıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a sister of ▯.",
     "gloss": "sister",
     "short": "",
@@ -8916,6 +9539,7 @@
   {
     "toaq": "lıqroaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a biological mother of ▯.",
     "gloss": "mother",
     "short": "",
@@ -8929,6 +9553,7 @@
   {
     "toaq": "lıqseo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a wife of ▯.",
     "gloss": "wife",
     "short": "",
@@ -8942,6 +9567,7 @@
   {
     "toaq": "lıq'ocha",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a female human; ▯ is a woman.",
     "gloss": "woman",
     "short": "",
@@ -8955,6 +9581,7 @@
   {
     "toaq": "lıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is beside ▯; ▯ is to the side of ▯; ▯ is next to ▯.",
     "gloss": "beside",
     "short": "",
@@ -8968,6 +9595,7 @@
   {
     "toaq": "lıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a ▯-tuple.",
     "gloss": "tuple",
     "short": "",
@@ -8981,6 +9609,7 @@
   {
     "toaq": "lıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ swims.",
     "gloss": "swim",
     "short": "",
@@ -8994,6 +9623,7 @@
   {
     "toaq": "lıao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a fungus/mushroom/mold.",
     "gloss": "fungus",
     "short": "",
@@ -9007,6 +9637,7 @@
   {
     "toaq": "lıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is light in weight.",
     "gloss": "light",
     "short": "",
@@ -9020,6 +9651,7 @@
   {
     "toaq": "lıo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is to the left of ▯.",
     "gloss": "left",
     "short": "",
@@ -9033,6 +9665,7 @@
   {
     "toaq": "lıopaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the left part of ▯.",
     "gloss": "left.part",
     "short": "",
@@ -9046,6 +9679,7 @@
   {
     "toaq": "lıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ experiences satisfying property ▯.",
     "gloss": "experience",
     "short": "",
@@ -9059,6 +9693,7 @@
   {
     "toaq": "lıecho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ likes satisfying property ▯.",
     "gloss": "like",
     "short": "",
@@ -9072,6 +9707,7 @@
   {
     "toaq": "lıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a wedge.",
     "gloss": "wedge",
     "short": "",
@@ -9085,6 +9721,7 @@
   {
     "toaq": "Lojıbaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the Lojban language.",
     "gloss": "Lojban",
     "short": "",
@@ -9098,6 +9735,7 @@
   {
     "toaq": "loq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is hot/warm.",
     "gloss": "hot",
     "short": "",
@@ -9111,6 +9749,7 @@
   {
     "toaq": "loqcao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a summer.",
     "gloss": "summer",
     "short": "",
@@ -9124,6 +9763,7 @@
   {
     "toaq": "loqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a heater.",
     "gloss": "heater",
     "short": "",
@@ -9137,6 +9777,7 @@
   {
     "toaq": "loa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is purple.",
     "gloss": "purple",
     "short": "",
@@ -9150,6 +9791,7 @@
   {
     "toaq": "loachaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Sunday.",
     "gloss": "sunday",
     "short": "",
@@ -9163,6 +9805,7 @@
   {
     "toaq": "loaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a buttocks/ass/behind.",
     "gloss": "buttocks",
     "short": "",
@@ -9176,6 +9819,7 @@
   {
     "toaq": "loaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ flows.",
     "gloss": "flow",
     "short": "",
@@ -9189,6 +9833,7 @@
   {
     "toaq": "loı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hates ▯.",
     "gloss": "hate",
     "short": "",
@@ -9202,6 +9847,7 @@
   {
     "toaq": "loe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a flame/fire.",
     "gloss": "flame",
     "short": "",
@@ -9215,6 +9861,7 @@
   {
     "toaq": "le",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is likely/probable.",
     "gloss": "likely",
     "short": "",
@@ -9233,6 +9880,7 @@
   {
     "toaq": "leq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tongue.",
     "gloss": "tongue",
     "short": "",
@@ -9246,6 +9894,7 @@
   {
     "toaq": "lea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is art.",
     "gloss": "art",
     "short": "",
@@ -9259,6 +9908,7 @@
   {
     "toaq": "leache",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an artist.",
     "gloss": "artist",
     "short": "",
@@ -9272,6 +9922,7 @@
   {
     "toaq": "leaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is adjacent to ▯ in property ▯.",
     "gloss": "adjacent",
     "short": "",
@@ -9285,6 +9936,7 @@
   {
     "toaq": "leaqbua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a neighbour of ▯.",
     "gloss": "neighbour",
     "short": "",
@@ -9298,6 +9950,7 @@
   {
     "toaq": "leaqfıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ immediately precedes ▯ in sequence ▯.",
     "gloss": "precede",
     "short": "",
@@ -9311,6 +9964,7 @@
   {
     "toaq": "leaqsıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ immediately follows ▯ in sequence ▯; ▯ is next after ▯ in sequence ▯.",
     "gloss": "next",
     "short": "",
@@ -9324,6 +9978,7 @@
   {
     "toaq": "leı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is rare in property ▯; ▯ satisfies rare/infrequent property ▯.",
     "gloss": "rare",
     "short": "",
@@ -9337,6 +9992,7 @@
   {
     "toaq": "leo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ tries to satisfy property ▯.",
     "gloss": "try",
     "short": "",
@@ -9351,6 +10007,7 @@
   {
     "toaq": "leoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ shields ▯ from ▯.",
     "gloss": "shield",
     "short": "",
@@ -9364,6 +10021,7 @@
   {
     "toaq": "leoqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a shield.",
     "gloss": "shield",
     "short": "",
@@ -9387,6 +10045,7 @@
   {
     "toaq": "mama",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is mama (Mom, mommy, mum, mother).",
     "gloss": "mama",
     "short": "",
@@ -9400,6 +10059,7 @@
   {
     "toaq": "mameı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter M.",
     "gloss": "M",
     "short": "",
@@ -9413,6 +10073,7 @@
   {
     "toaq": "mateoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a polar yes-no question.",
     "gloss": "",
     "short": "",
@@ -9439,6 +10100,7 @@
   {
     "toaq": "maı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ loves ▯.",
     "gloss": "love",
     "short": "",
@@ -9452,6 +10114,7 @@
   {
     "toaq": "maıgaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a boyfriend/girlfriend/SO of ▯.",
     "gloss": "SO",
     "short": "",
@@ -9465,6 +10128,7 @@
   {
     "toaq": "maıjuo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a love letter.",
     "gloss": "love.letter",
     "short": "",
@@ -9488,6 +10152,7 @@
   {
     "toaq": "maoja",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a banana.",
     "gloss": "banana",
     "short": "",
@@ -9514,6 +10179,7 @@
   {
     "toaq": "maybo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ours (1st + 2nd + 3rd person).",
     "gloss": "our",
     "short": "",
@@ -9527,6 +10193,7 @@
   {
     "toaq": "mu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ satisfies property ▯ with the first and second places swapped.",
     "gloss": "-ed",
     "short": "",
@@ -9549,6 +10216,7 @@
   {
     "toaq": "muq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hand.",
     "gloss": "hand",
     "short": "",
@@ -9562,6 +10230,7 @@
   {
     "toaq": "muqcheı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a finger.",
     "gloss": "finger",
     "short": "",
@@ -9575,6 +10244,7 @@
   {
     "toaq": "muqcheıbea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a knuckle.",
     "gloss": "knuckle",
     "short": "",
@@ -9588,6 +10258,7 @@
   {
     "toaq": "muqcea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a handbag.",
     "gloss": "handbag",
     "short": "",
@@ -9601,6 +10272,7 @@
   {
     "toaq": "muqdea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ punches ▯.",
     "gloss": "punch",
     "short": "",
@@ -9614,6 +10286,7 @@
   {
     "toaq": "muqfuq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a glove.",
     "gloss": "glove",
     "short": "",
@@ -9627,6 +10300,7 @@
   {
     "toaq": "mua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an example of ▯.",
     "gloss": "example",
     "short": "",
@@ -9640,6 +10314,7 @@
   {
     "toaq": "muaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is dead.",
     "gloss": "dead",
     "short": "",
@@ -9653,6 +10328,7 @@
   {
     "toaq": "muaqsho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ dies.",
     "gloss": "die",
     "short": "",
@@ -9666,6 +10342,7 @@
   {
     "toaq": "muaqtua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ kills ▯.",
     "gloss": "kill",
     "short": "",
@@ -9679,6 +10356,7 @@
   {
     "toaq": "muaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ has an umami taste.",
     "gloss": "umami",
     "short": "",
@@ -9692,6 +10370,7 @@
   {
     "toaq": "muao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tree.",
     "gloss": "tree",
     "short": "",
@@ -9705,6 +10384,7 @@
   {
     "toaq": "muaoguaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a forest.",
     "gloss": "forest",
     "short": "",
@@ -9718,6 +10398,7 @@
   {
     "toaq": "muaome",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a forest.",
     "gloss": "forest",
     "short": "",
@@ -9731,6 +10412,7 @@
   {
     "toaq": "muı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a meaning of ▯.",
     "gloss": "meaning",
     "short": "",
@@ -9744,6 +10426,7 @@
   {
     "toaq": "muıdua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ understands the meaning of ▯.",
     "gloss": "understand",
     "short": "",
@@ -9757,6 +10440,7 @@
   {
     "toaq": "muo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is whole/complete in aspect ▯.",
     "gloss": "whole",
     "short": "",
@@ -9770,6 +10454,7 @@
   {
     "toaq": "muotua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ mends ▯; ▯ makes ▯ whole; ▯ completes ▯.",
     "gloss": "mend",
     "short": "",
@@ -9783,6 +10468,7 @@
   {
     "toaq": "muo gỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is perfect.",
     "gloss": "perfect",
     "short": "",
@@ -9796,6 +10482,7 @@
   {
     "toaq": "muoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is made of ▯.",
     "gloss": "made.of",
     "short": "",
@@ -9809,6 +10496,7 @@
   {
     "toaq": "muoı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ rotates/spins/turns.",
     "gloss": "rotate",
     "short": "",
@@ -9835,6 +10523,7 @@
   {
     "toaq": "muybo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ours (1st + 2nd person).",
     "gloss": "our",
     "short": "",
@@ -9861,6 +10550,7 @@
   {
     "toaq": "mınu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a minute.",
     "gloss": "minute",
     "short": "",
@@ -9887,6 +10577,7 @@
   {
     "toaq": "mıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is infinite in property ▯.",
     "gloss": "infinite",
     "short": "",
@@ -9900,6 +10591,7 @@
   {
     "toaq": "mıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is rich in relation ▯; ▯ is in relation ▯ to/with many things.",
     "gloss": "rich",
     "short": "",
@@ -9914,6 +10606,7 @@
   {
     "toaq": "mıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the value of ▯.",
     "gloss": "value",
     "short": "",
@@ -9927,6 +10620,7 @@
   {
     "toaq": "mıaqgaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ appreciates/esteems ▯.",
     "gloss": "esteem",
     "short": "",
@@ -9940,6 +10634,7 @@
   {
     "toaq": "mıaqjıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ appreciates ▯.",
     "gloss": "appreciate",
     "short": "",
@@ -9953,6 +10648,7 @@
   {
     "toaq": "mıaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ rhymes with ▯.",
     "gloss": "rhyme",
     "short": "",
@@ -9966,6 +10662,7 @@
   {
     "toaq": "mıaıse",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a rhyme.",
     "gloss": "rhyme",
     "short": "",
@@ -9979,6 +10676,7 @@
   {
     "toaq": "mıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a moon.",
     "gloss": "moon",
     "short": "",
@@ -9992,6 +10690,7 @@
   {
     "toaq": "mıu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ opines/thinks that ▯ is the case.",
     "gloss": "opine",
     "short": "",
@@ -10005,6 +10704,7 @@
   {
     "toaq": "mıujeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ agrees with ▯ that ▯ is the case.",
     "gloss": "agree",
     "short": "",
@@ -10019,6 +10719,7 @@
   {
     "toaq": "mıo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is blue.",
     "gloss": "blue",
     "short": "",
@@ -10032,6 +10733,7 @@
   {
     "toaq": "mıochaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Saturday.",
     "gloss": "saturday",
     "short": "",
@@ -10045,6 +10747,7 @@
   {
     "toaq": "mıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ lives / is alive.",
     "gloss": "alive",
     "short": "",
@@ -10058,6 +10761,7 @@
   {
     "toaq": "mıefea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ survives ▯.",
     "gloss": "survive",
     "short": "",
@@ -10071,6 +10775,7 @@
   {
     "toaq": "mıehua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a heart.",
     "gloss": "heart",
     "short": "",
@@ -10084,6 +10789,7 @@
   {
     "toaq": "mıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ measures/evaluates/determines what satisfies property ▯.",
     "gloss": "measure",
     "short": "",
@@ -10110,6 +10816,7 @@
   {
     "toaq": "mıybo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ours (1st + 3rd person).",
     "gloss": "our",
     "short": "",
@@ -10156,6 +10863,7 @@
   {
     "toaq": "moa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a point in ▯.",
     "gloss": "point",
     "short": "",
@@ -10169,6 +10877,7 @@
   {
     "toaq": "moaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ remembers ▯.",
     "gloss": "remember",
     "short": "",
@@ -10182,6 +10891,7 @@
   {
     "toaq": "moaqchuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a mnemonic for remembering ▯.",
     "gloss": "mnemonic",
     "short": "",
@@ -10195,6 +10905,7 @@
   {
     "toaq": "moaqshaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ forgets ▯.",
     "gloss": "forget",
     "short": "",
@@ -10208,6 +10919,7 @@
   {
     "toaq": "moaqsıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a memory.",
     "gloss": "memory",
     "short": "",
@@ -10221,6 +10933,7 @@
   {
     "toaq": "moaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is thick.",
     "gloss": "thick",
     "short": "",
@@ -10234,6 +10947,7 @@
   {
     "toaq": "moı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ thinks / is having a thought; ▯ thinks thought ▯.",
     "gloss": "think",
     "short": "",
@@ -10247,6 +10961,7 @@
   {
     "toaq": "moıhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a brain.",
     "gloss": "brain",
     "short": "",
@@ -10260,6 +10975,7 @@
   {
     "toaq": "moıjoe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is clever/smart/witty/intelligent.",
     "gloss": "clever",
     "short": "",
@@ -10273,6 +10989,7 @@
   {
     "toaq": "moılao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hesitates.",
     "gloss": "hesitate",
     "short": "",
@@ -10286,6 +11003,7 @@
   {
     "toaq": "moınıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is dumb/stupid/unintelligent.",
     "gloss": "stupid",
     "short": "",
@@ -10299,6 +11017,7 @@
   {
     "toaq": "moısı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ ponders / concentrates mentally on ▯.",
     "gloss": "ponder",
     "short": "",
@@ -10312,6 +11031,7 @@
   {
     "toaq": "moıse",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a thought.",
     "gloss": "thought",
     "short": "",
@@ -10325,6 +11045,7 @@
   {
     "toaq": "moe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ experiences emotion ▯.",
     "gloss": "feel",
     "short": "",
@@ -10345,6 +11066,7 @@
   {
     "toaq": "moehua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an organ of feeling/emotion (“heart”).",
     "gloss": "organ.of.feeling",
     "short": "",
@@ -10358,6 +11080,7 @@
   {
     "toaq": "moerıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a heart/emotional/spiritual center/core.",
     "gloss": "center.of.emotion",
     "short": "",
@@ -10371,6 +11094,7 @@
   {
     "toaq": "me",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is an aggregate of ▯.",
     "gloss": "aggregate",
     "short": "",
@@ -10384,6 +11108,7 @@
   {
     "toaq": "mega",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>6</sup> (1,000,000) in number; ▯ are a million.",
     "gloss": "mega",
     "short": "",
@@ -10397,6 +11122,7 @@
   {
     "toaq": "merıka",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is America (continent).",
     "gloss": "America",
     "short": "",
@@ -10410,6 +11136,7 @@
   {
     "toaq": "mety",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a meter.",
     "gloss": "meter",
     "short": "",
@@ -10436,6 +11163,7 @@
   {
     "toaq": "meaheo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is different from ▯; ▯ is not the same thing as ▯; ▯ is something else than ▯.",
     "gloss": "other",
     "short": "",
@@ -10451,6 +11179,7 @@
   {
     "toaq": "meajeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the same thing as ▯.",
     "gloss": "same",
     "short": "",
@@ -10466,6 +11195,7 @@
   {
     "toaq": "meakuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ mentions ▯ to ▯.",
     "gloss": "mention",
     "short": "",
@@ -10479,6 +11209,7 @@
   {
     "toaq": "meaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a ship/boat/vessel.",
     "gloss": "ship",
     "short": "",
@@ -10492,6 +11223,7 @@
   {
     "toaq": "meaqce",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a harbour/haven.",
     "gloss": "harbour",
     "short": "",
@@ -10505,6 +11237,7 @@
   {
     "toaq": "meı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a mountain/hill.",
     "gloss": "mountain",
     "short": "",
@@ -10518,6 +11251,7 @@
   {
     "toaq": "meırıe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a valley.",
     "gloss": "valley",
     "short": "",
@@ -10531,6 +11265,7 @@
   {
     "toaq": "meo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is sad.",
     "gloss": "sad",
     "short": "",
@@ -10544,6 +11279,7 @@
   {
     "toaq": "meoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is slow; ▯ slowly satisfies property ▯.",
     "gloss": "slow",
     "short": "",
@@ -10557,6 +11293,7 @@
   {
     "toaq": "meoqkoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ walks.",
     "gloss": "walk",
     "short": "",
@@ -10580,6 +11317,7 @@
   {
     "toaq": "naby",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is bread.",
     "gloss": "bread",
     "short": "",
@@ -10593,6 +11331,7 @@
   {
     "toaq": "nanaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter N.",
     "gloss": "N",
     "short": "",
@@ -10606,6 +11345,7 @@
   {
     "toaq": "naraq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is of orange color.",
     "gloss": "orange",
     "short": "",
@@ -10619,6 +11359,7 @@
   {
     "toaq": "naraqchaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Tuesday.",
     "gloss": "tuesday",
     "short": "",
@@ -10632,6 +11373,7 @@
   {
     "toaq": "naq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is male.",
     "gloss": "male",
     "short": "",
@@ -10645,6 +11387,7 @@
   {
     "toaq": "naqdeo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a boy.",
     "gloss": "boy",
     "short": "",
@@ -10658,6 +11401,7 @@
   {
     "toaq": "naqfu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a son (male biological offspring) of ▯.",
     "gloss": "son",
     "short": "",
@@ -10671,6 +11415,7 @@
   {
     "toaq": "naqpao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a father of ▯; acts as a father towards ▯.",
     "gloss": "father",
     "short": "",
@@ -10684,6 +11429,7 @@
   {
     "toaq": "naqpıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a brother of ▯.",
     "gloss": "brother",
     "short": "",
@@ -10697,6 +11443,7 @@
   {
     "toaq": "naqroaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a biological father of ▯.",
     "gloss": "father",
     "short": "",
@@ -10710,6 +11457,7 @@
   {
     "toaq": "naqseo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a husband of ▯.",
     "gloss": "husband",
     "short": "",
@@ -10723,6 +11471,7 @@
   {
     "toaq": "naq'ocha",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a male human; ▯ is a man.",
     "gloss": "man",
     "short": "",
@@ -10736,6 +11485,7 @@
   {
     "toaq": "naı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens now.",
     "gloss": "PRE",
     "short": "",
@@ -10750,6 +11500,7 @@
   {
     "toaq": "nao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is water.",
     "gloss": "water",
     "short": "",
@@ -10763,6 +11514,7 @@
   {
     "toaq": "naoguaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an island.",
     "gloss": "island",
     "short": "",
@@ -10776,6 +11528,7 @@
   {
     "toaq": "naokua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bathroom.",
     "gloss": "bathroom",
     "short": "",
@@ -10789,6 +11542,7 @@
   {
     "toaq": "naonıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an aquatic life form.",
     "gloss": "aquatic.life",
     "short": "",
@@ -10802,6 +11556,7 @@
   {
     "toaq": "nu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is such / is like that.",
     "gloss": "such",
     "short": "",
@@ -10820,6 +11575,7 @@
   {
     "toaq": "nuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a worm-like animal (animal with long cylindrical tube-like body and no limbs or with short limbs but crawling) (form classification).",
     "gloss": "worm-like",
     "short": "",
@@ -10833,6 +11589,7 @@
   {
     "toaq": "nua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ takes/removes property ▯ from ▯.",
     "gloss": "take",
     "short": "",
@@ -10846,6 +11603,7 @@
   {
     "toaq": "nuakoe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ picks ▯; ▯ chooses and takes ▯.",
     "gloss": "pick",
     "short": "",
@@ -10859,6 +11617,7 @@
   {
     "toaq": "nuaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a night.",
     "gloss": "night",
     "short": "",
@@ -10872,6 +11631,7 @@
   {
     "toaq": "nuaqchu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is midnight.",
     "gloss": "midnight",
     "short": "",
@@ -10885,6 +11645,7 @@
   {
     "toaq": "nuaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is money.",
     "gloss": "money",
     "short": "",
@@ -10898,6 +11659,7 @@
   {
     "toaq": "nuaıjıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bank.",
     "gloss": "bank",
     "short": "",
@@ -10911,6 +11673,7 @@
   {
     "toaq": "nuao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is an arch; ▯ arches.",
     "gloss": "arch",
     "short": "",
@@ -10924,6 +11687,7 @@
   {
     "toaq": "nuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is small/little.",
     "gloss": "small",
     "short": "",
@@ -10937,6 +11701,7 @@
   {
     "toaq": "nuıdoaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a town.",
     "gloss": "town",
     "short": "",
@@ -10950,6 +11715,7 @@
   {
     "toaq": "nuo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ sleeps / is asleep.",
     "gloss": "sleep",
     "short": "",
@@ -10963,6 +11729,7 @@
   {
     "toaq": "nuofa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ goes to bed.",
     "gloss": "go.to.bed",
     "short": "",
@@ -10976,6 +11743,7 @@
   {
     "toaq": "nuofuq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a pyjama.",
     "gloss": "pyjama",
     "short": "",
@@ -10989,6 +11757,7 @@
   {
     "toaq": "nuofua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bed.",
     "gloss": "bed",
     "short": "",
@@ -11002,6 +11771,7 @@
   {
     "toaq": "nuokua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bedroom.",
     "gloss": "bedroom",
     "short": "",
@@ -11015,6 +11785,7 @@
   {
     "toaq": "nuokuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is tired.",
     "gloss": "tired",
     "short": "",
@@ -11028,6 +11799,7 @@
   {
     "toaq": "nuosho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ falls asleep.",
     "gloss": "fall.asleep",
     "short": "",
@@ -11041,6 +11813,7 @@
   {
     "toaq": "nuoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ reflects/mirrors/echoes ▯.",
     "gloss": "reflect",
     "short": "",
@@ -11054,6 +11827,7 @@
   {
     "toaq": "nuoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ chews; ▯ chews ▯; ▯ chews on ▯.",
     "gloss": "masticate",
     "short": "",
@@ -11067,6 +11841,7 @@
   {
     "toaq": "nue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ promises/threatens to ▯ to satisfy property ▯.",
     "gloss": "promise",
     "short": "",
@@ -11080,6 +11855,7 @@
   {
     "toaq": "nueq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is meat/flesh.",
     "gloss": "meat",
     "short": "",
@@ -11103,6 +11879,7 @@
   {
     "toaq": "nhanhoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Nh.",
     "gloss": "Nh",
     "short": "",
@@ -11129,6 +11906,7 @@
   {
     "toaq": "nhaobo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is his/hers/theirs.",
     "gloss": "their",
     "short": "",
@@ -11162,11 +11940,12 @@
   {
     "toaq": "nhe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an event with ▯ as its extent.",
     "gloss": "extent",
     "short": "",
     "keywords": [],
-    "frame": "c c",
+    "frame": "0 c",
     "distribution": "d d",
     "notes": [],
     "examples": [],
@@ -11175,6 +11954,7 @@
   {
     "toaq": "nı",
     "type": "predicate",
+    "animacy": "bou",
     "english": "▯ is this/that; ▯ is this/that/those thing(s) satisfying property ▯.",
     "gloss": "this",
     "short": "",
@@ -11188,6 +11968,7 @@
   {
     "toaq": "nıchaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is today.",
     "gloss": "today",
     "short": "",
@@ -11201,6 +11982,7 @@
   {
     "toaq": "nıdaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the now.",
     "gloss": "now",
     "short": "",
@@ -11214,6 +11996,7 @@
   {
     "toaq": "nıjao",
     "type": "predicate",
+    "animacy": "bou",
     "english": "▯ is that far away thing.",
     "gloss": "far.away",
     "short": "",
@@ -11227,6 +12010,7 @@
   {
     "toaq": "nıjuı",
     "type": "predicate",
+    "animacy": "bou",
     "english": "▯ is this nearby thing.",
     "gloss": "nearby",
     "short": "",
@@ -11240,6 +12024,7 @@
   {
     "toaq": "nınuaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is tonight.",
     "gloss": "tonight",
     "short": "",
@@ -11253,6 +12038,7 @@
   {
     "toaq": "nıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is new; ▯ is new to ▯.",
     "gloss": "new",
     "short": "",
@@ -11266,6 +12052,7 @@
   {
     "toaq": "nıqchıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a beginner/newbie at skill/subject ▯.",
     "gloss": "beginner",
     "short": "",
@@ -11279,6 +12066,7 @@
   {
     "toaq": "nıqdao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ are news.",
     "gloss": "news",
     "short": "",
@@ -11292,6 +12080,7 @@
   {
     "toaq": "nıqdua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ discovers / finds out ▯.",
     "gloss": "discover",
     "short": "",
@@ -11305,6 +12094,7 @@
   {
     "toaq": "nıqguo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens again.",
     "gloss": "again",
     "short": "",
@@ -11318,6 +12108,7 @@
   {
     "toaq": "nıqguokuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ misses ▯; ▯ hungers for ▯ to happen again.",
     "gloss": "miss",
     "short": "",
@@ -11331,6 +12122,7 @@
   {
     "toaq": "nıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is low.",
     "gloss": "low",
     "short": "",
@@ -11344,6 +12136,7 @@
   {
     "toaq": "nıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a year.",
     "gloss": "year",
     "short": "",
@@ -11357,6 +12150,7 @@
   {
     "toaq": "nıaqdıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is annual.",
     "gloss": "annual",
     "short": "",
@@ -11370,6 +12164,7 @@
   {
     "toaq": "nıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is an animal.",
     "gloss": "animal",
     "short": "",
@@ -11383,6 +12178,7 @@
   {
     "toaq": "nıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is snow.",
     "gloss": "snow",
     "short": "",
@@ -11396,6 +12192,7 @@
   {
     "toaq": "nıaoshua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "It snows; ▯ snows; ▯ snows onto ▯.",
     "gloss": "snow",
     "short": "",
@@ -11414,6 +12211,7 @@
   {
     "toaq": "nıu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a plant.",
     "gloss": "plant",
     "short": "",
@@ -11427,6 +12225,7 @@
   {
     "toaq": "nıuboe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a leaf (of a plant).",
     "gloss": "leaf",
     "short": "",
@@ -11440,6 +12239,7 @@
   {
     "toaq": "nıo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is young.",
     "gloss": "young",
     "short": "",
@@ -11453,6 +12253,7 @@
   {
     "toaq": "nıode",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is cute.",
     "gloss": "cute",
     "short": "",
@@ -11466,6 +12267,7 @@
   {
     "toaq": "nıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tooth.",
     "gloss": "tooth",
     "short": "",
@@ -11479,6 +12281,7 @@
   {
     "toaq": "nıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is inside ▯.",
     "gloss": "inside",
     "short": "",
@@ -11492,6 +12295,7 @@
   {
     "toaq": "nıefa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ enters / goes inside ▯.",
     "gloss": "enter",
     "short": "",
@@ -11505,6 +12309,7 @@
   {
     "toaq": "nıeshua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ falls into ▯.",
     "gloss": "fall.in",
     "short": "",
@@ -11518,6 +12323,7 @@
   {
     "toaq": "nıetua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ puts ▯ inside ▯.",
     "gloss": "insert",
     "short": "",
@@ -11531,6 +12337,7 @@
   {
     "toaq": "nıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is unskilled at satisfying property ▯.",
     "gloss": "unskilled",
     "short": "",
@@ -11544,6 +12351,7 @@
   {
     "toaq": "no",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is in format/medium/genre ▯.",
     "gloss": "in",
     "short": "",
@@ -11566,6 +12374,7 @@
   {
     "toaq": "noq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is gustatory; ▯ pertains to the sense of taste/gustation.",
     "gloss": "gustatory",
     "short": "",
@@ -11579,6 +12388,7 @@
   {
     "toaq": "noqgaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ tastes state of affairs ▯.",
     "gloss": "taste",
     "short": "",
@@ -11592,6 +12402,7 @@
   {
     "toaq": "noqgı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ tastes good / is delicious; ▯ tastes good / is delicious to ▯.",
     "gloss": "delicious",
     "short": "",
@@ -11605,6 +12416,7 @@
   {
     "toaq": "noqhuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ tastes bad; ▯ tastes bad to ▯.",
     "gloss": "taste.bad",
     "short": "",
@@ -11618,6 +12430,7 @@
   {
     "toaq": "noqsı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ listens to the taste of ▯.",
     "gloss": "taste-listen",
     "short": "",
@@ -11631,6 +12444,7 @@
   {
     "toaq": "noa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "Satisfying property ▯ is difficult for ▯.",
     "gloss": "difficult",
     "short": "",
@@ -11644,6 +12458,7 @@
   {
     "toaq": "noaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ reads ▯.",
     "gloss": "read",
     "short": "",
@@ -11657,6 +12472,7 @@
   {
     "toaq": "noaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is milk.",
     "gloss": "milk",
     "short": "",
@@ -11670,6 +12486,7 @@
   {
     "toaq": "noı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is pain.",
     "gloss": "pain",
     "short": "",
@@ -11683,6 +12500,7 @@
   {
     "toaq": "noılıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ suffers / has pain.",
     "gloss": "suffer",
     "short": "",
@@ -11696,6 +12514,7 @@
   {
     "toaq": "ne",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is how much ▯ is the case; ▯ is the amount that ▯ is the case.",
     "gloss": "amount",
     "short": "",
@@ -11709,6 +12528,7 @@
   {
     "toaq": "neq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is determined by the luck/fortune of ▯.",
     "gloss": "luck",
     "short": "",
@@ -11724,6 +12544,7 @@
   {
     "toaq": "nea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is wide/broad.",
     "gloss": "wide",
     "short": "",
@@ -11737,6 +12558,7 @@
   {
     "toaq": "neı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are nine in number.",
     "gloss": "nine",
     "short": "",
@@ -11750,6 +12572,7 @@
   {
     "toaq": "neıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is ninth among ▯.",
     "gloss": "ninth",
     "short": "",
@@ -11763,6 +12586,7 @@
   {
     "toaq": "neo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is on ▯.",
     "gloss": "on",
     "short": "",
@@ -11776,6 +12600,7 @@
   {
     "toaq": "neoq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a Mr./Mrs./Ms./Miss.",
     "gloss": "mr/mrs",
     "short": "",
@@ -11789,6 +12614,7 @@
   {
     "toaq": "papa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is papa (Dad, daddy, father).",
     "gloss": "papa",
     "short": "",
@@ -11802,6 +12628,7 @@
   {
     "toaq": "patı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a party (gathering for entertainment, fun and socializing).",
     "gloss": "party",
     "short": "",
@@ -11815,6 +12642,7 @@
   {
     "toaq": "paq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a part of ▯.",
     "gloss": "part",
     "short": "",
@@ -11828,6 +12656,7 @@
   {
     "toaq": "paqcıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lacks part ▯; ▯ is missing part ▯.",
     "gloss": "lack",
     "short": "",
@@ -11841,6 +12670,7 @@
   {
     "toaq": "paqmuo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is whole/complete.",
     "gloss": "whole",
     "short": "",
@@ -11854,6 +12684,7 @@
   {
     "toaq": "paqnua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ removes part ▯ from ▯.",
     "gloss": "remove",
     "short": "",
@@ -11867,6 +12698,7 @@
   {
     "toaq": "paqshaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ loses part ▯.",
     "gloss": "lose",
     "short": "",
@@ -11880,6 +12712,7 @@
   {
     "toaq": "paqtao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ takes part in ▯; ▯ participates in ▯.",
     "gloss": "participate",
     "short": "",
@@ -11893,6 +12726,7 @@
   {
     "toaq": "paı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a friend; ▯ is a friend of ▯.",
     "gloss": "friend",
     "short": "",
@@ -11907,6 +12741,7 @@
   {
     "toaq": "paıgı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is friendly towards ▯.",
     "gloss": "friendly",
     "short": "",
@@ -11920,6 +12755,7 @@
   {
     "toaq": "paıruo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ acts friendly/kindly towards ▯.",
     "gloss": "friendly",
     "short": "",
@@ -11933,6 +12769,7 @@
   {
     "toaq": "pao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a parent of ▯; ▯ acts parental towards ▯; ▯ raises ▯.",
     "gloss": "parent",
     "short": "",
@@ -11946,6 +12783,7 @@
   {
     "toaq": "pu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happened / occured / was the case.",
     "gloss": "PST",
     "short": "",
@@ -11959,6 +12797,7 @@
   {
     "toaq": "puchaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is yesterday.",
     "gloss": "yesterday",
     "short": "",
@@ -11972,6 +12811,7 @@
   {
     "toaq": "pujao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happened a long time ago.",
     "gloss": "long.ago",
     "short": "",
@@ -11985,6 +12825,7 @@
   {
     "toaq": "pujuı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happened a short time ago.",
     "gloss": "shortly.ago",
     "short": "",
@@ -11998,6 +12839,7 @@
   {
     "toaq": "puq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are more than one / multiple things.",
     "gloss": "multiple",
     "short": "",
@@ -12011,6 +12853,7 @@
   {
     "toaq": "puqho",
     "type": "predicate",
+    "animacy": "fuy",
     "english": "▯ are them.",
     "gloss": "they",
     "short": "",
@@ -12024,6 +12867,7 @@
   {
     "toaq": "pua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ enjoys satisfying property ▯.",
     "gloss": "enjoy",
     "short": "",
@@ -12037,6 +12881,7 @@
   {
     "toaq": "puaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is somatic/tactile; ▯ pertains to the sense of touch/somatosensation.",
     "gloss": "somatic",
     "short": "",
@@ -12050,6 +12895,7 @@
   {
     "toaq": "puaqgaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ touch feels ▯.",
     "gloss": "touch.feel",
     "short": "",
@@ -12063,6 +12909,7 @@
   {
     "toaq": "puaqgı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is nice to the touch; ▯ is nice to the touch of ▯.",
     "gloss": "feel.good",
     "short": "",
@@ -12076,6 +12923,7 @@
   {
     "toaq": "puaqsı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ focuses on touch feeling ▯.",
     "gloss": "touch.feel",
     "short": "",
@@ -12089,6 +12937,7 @@
   {
     "toaq": "puaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is wild/untamed.",
     "gloss": "wild",
     "short": "",
@@ -12102,6 +12951,7 @@
   {
     "toaq": "puao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a cloud.",
     "gloss": "cloud",
     "short": "",
@@ -12115,6 +12965,7 @@
   {
     "toaq": "puı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are many.",
     "gloss": "many",
     "short": "",
@@ -12128,6 +12979,7 @@
   {
     "toaq": "puıjeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are equal in number to ▯; ▯ and ▯ are equinumerous.",
     "gloss": "same.number",
     "short": "",
@@ -12141,6 +12993,7 @@
   {
     "toaq": "puıpoqchao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bus/omnibus.",
     "gloss": "bus",
     "short": "",
@@ -12154,6 +13007,7 @@
   {
     "toaq": "puısho",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ multiplies.",
     "gloss": "multiply",
     "short": "",
@@ -12167,6 +13021,7 @@
   {
     "toaq": "puısıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are zero in number; ▯ are none.",
     "gloss": "zero",
     "short": "",
@@ -12180,6 +13035,7 @@
   {
     "toaq": "puıtua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ multiplies ▯.",
     "gloss": "multiply",
     "short": "",
@@ -12193,6 +13049,7 @@
   {
     "toaq": "puıtuao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are few in number.",
     "gloss": "few",
     "short": "",
@@ -12206,6 +13063,7 @@
   {
     "toaq": "puo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is powder.",
     "gloss": "powder",
     "short": "",
@@ -12219,6 +13077,7 @@
   {
     "toaq": "pue",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a foot.",
     "gloss": "foot",
     "short": "",
@@ -12232,6 +13091,7 @@
   {
     "toaq": "puebea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a knee.",
     "gloss": "knee",
     "short": "",
@@ -12245,6 +13105,7 @@
   {
     "toaq": "puecheı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a toe.",
     "gloss": "toe",
     "short": "",
@@ -12258,6 +13119,7 @@
   {
     "toaq": "puedea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ kicks ▯.",
     "gloss": "kick",
     "short": "",
@@ -12271,6 +13133,7 @@
   {
     "toaq": "puefuq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a shoe.",
     "gloss": "shoe",
     "short": "",
@@ -12284,6 +13147,7 @@
   {
     "toaq": "puegao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sock.",
     "gloss": "sock",
     "short": "",
@@ -12297,6 +13161,7 @@
   {
     "toaq": "pueshıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hip.",
     "gloss": "hip",
     "short": "",
@@ -12310,6 +13175,7 @@
   {
     "toaq": "pueq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ steps/treads on ▯.",
     "gloss": "tread",
     "short": "",
@@ -12323,6 +13189,7 @@
   {
     "toaq": "pı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is urine/pee/piss.",
     "gloss": "urine",
     "short": "",
@@ -12336,6 +13203,7 @@
   {
     "toaq": "pıcıu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ urinates/pees/pisses.",
     "gloss": "urinate",
     "short": "",
@@ -12349,6 +13217,7 @@
   {
     "toaq": "pıjama",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a pyjama.",
     "gloss": "pyjama",
     "short": "",
@@ -12362,6 +13231,7 @@
   {
     "toaq": "pıpoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter P.",
     "gloss": "P",
     "short": "",
@@ -12375,6 +13245,7 @@
   {
     "toaq": "pıso",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a pear.",
     "gloss": "pear",
     "short": "",
@@ -12388,6 +13259,7 @@
   {
     "toaq": "pıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a sibling of ▯.",
     "gloss": "sibling",
     "short": "",
@@ -12401,6 +13273,7 @@
   {
     "toaq": "pıano",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a piano.",
     "gloss": "piano",
     "short": "",
@@ -12414,6 +13287,7 @@
   {
     "toaq": "pıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is complicated/complex.",
     "gloss": "complicated",
     "short": "",
@@ -12427,6 +13301,7 @@
   {
     "toaq": "pıu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is skin/peel/crust/hide/rind/outer cover.",
     "gloss": "skin",
     "short": "",
@@ -12440,6 +13315,7 @@
   {
     "toaq": "pıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is rock (material).",
     "gloss": "rock",
     "short": "",
@@ -12453,6 +13329,7 @@
   {
     "toaq": "pıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ drinks ▯.",
     "gloss": "drink",
     "short": "",
@@ -12466,6 +13343,7 @@
   {
     "toaq": "pıekuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is thirsty.",
     "gloss": "thirsty",
     "short": "",
@@ -12492,6 +13370,7 @@
   {
     "toaq": "poq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a person.",
     "gloss": "person",
     "short": "",
@@ -12506,6 +13385,7 @@
   {
     "toaq": "poqme",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a group of people.",
     "gloss": "group.of.people",
     "short": "",
@@ -12519,6 +13399,7 @@
   {
     "toaq": "poa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is closed/shut.",
     "gloss": "closed",
     "short": "",
@@ -12532,6 +13413,7 @@
   {
     "toaq": "poaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ breaks/parts/splits.",
     "gloss": "break",
     "short": "",
@@ -12545,6 +13427,7 @@
   {
     "toaq": "poaqse",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a shard/cullet.",
     "gloss": "shard",
     "short": "",
@@ -12558,6 +13441,7 @@
   {
     "toaq": "poaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a seed/spore/egg/gamete/ovum/sperm/pollen.",
     "gloss": "seed",
     "short": "",
@@ -12571,6 +13455,7 @@
   {
     "toaq": "poıba",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is grass.",
     "gloss": "grass",
     "short": "",
@@ -12584,6 +13469,7 @@
   {
     "toaq": "poe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is apart/separate from ▯ in property ▯.",
     "gloss": "apart",
     "short": "",
@@ -12597,6 +13483,7 @@
   {
     "toaq": "pe",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the case for/by the standard of ▯.",
     "gloss": "for",
     "short": "",
@@ -12616,6 +13503,7 @@
   {
     "toaq": "peta",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>15</sup> (1,000,000,000,000,000) in number; ▯ are a quadrillion.",
     "gloss": "peta",
     "short": "",
@@ -12629,6 +13517,7 @@
   {
     "toaq": "peq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is paper.",
     "gloss": "paper",
     "short": "",
@@ -12642,6 +13531,7 @@
   {
     "toaq": "peqboe",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sheet of paper.",
     "gloss": "sheet",
     "short": "",
@@ -12655,6 +13545,7 @@
   {
     "toaq": "pea",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happened ▯ (amount of time) ago.",
     "gloss": "ago",
     "short": "",
@@ -12673,6 +13564,7 @@
   {
     "toaq": "peo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ passes through ▯.",
     "gloss": "through",
     "short": "",
@@ -12696,6 +13588,7 @@
   {
     "toaq": "radıo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ pertains to radio transmission.",
     "gloss": "radio",
     "short": "",
@@ -12709,6 +13602,7 @@
   {
     "toaq": "raq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ pertains to / is about ▯.",
     "gloss": "about",
     "short": "",
@@ -12722,6 +13616,7 @@
   {
     "toaq": "raqmoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ thinks about ▯.",
     "gloss": "think.about",
     "short": "",
@@ -12735,6 +13630,7 @@
   {
     "toaq": "raı",
     "type": "predicate",
+    "animacy": "raı",
     "english": "▯ is something.",
     "gloss": "something",
     "short": "",
@@ -12748,6 +13644,7 @@
   {
     "toaq": "raıjeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the same thing as ▯.",
     "gloss": "same",
     "short": "",
@@ -12761,6 +13658,7 @@
   {
     "toaq": "raırua",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter R.",
     "gloss": "R",
     "short": "",
@@ -12774,6 +13672,7 @@
   {
     "toaq": "rao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens at the same time as ▯; ▯ is simultaneous with ▯.",
     "gloss": "when",
     "short": "",
@@ -12814,6 +13713,7 @@
   {
     "toaq": "ruq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is rain.",
     "gloss": "rain",
     "short": "",
@@ -12827,6 +13727,7 @@
   {
     "toaq": "ruqdıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a raindrop.",
     "gloss": "raindrop",
     "short": "",
@@ -12840,6 +13741,7 @@
   {
     "toaq": "ruqnuao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a rainbow.",
     "gloss": "rainbow",
     "short": "",
@@ -12853,6 +13755,7 @@
   {
     "toaq": "ruqshua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "It rains; ▯ rains; ▯ rains onto ▯.",
     "gloss": "rain",
     "short": "",
@@ -12871,6 +13774,7 @@
   {
     "toaq": "rua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a flower.",
     "gloss": "flower",
     "short": "",
@@ -12884,6 +13788,7 @@
   {
     "toaq": "ruaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ asserts/claims ▯ to be the case.",
     "gloss": "assert",
     "short": "",
@@ -12897,6 +13802,7 @@
   {
     "toaq": "ruaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is royal/noble/aristocratic.",
     "gloss": "royal",
     "short": "",
@@ -12910,6 +13816,7 @@
   {
     "toaq": "ruaıchea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a crown.",
     "gloss": "crown",
     "short": "",
@@ -12923,6 +13830,7 @@
   {
     "toaq": "ruaıjoaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a king/queen.",
     "gloss": "king/queen",
     "short": "",
@@ -12936,6 +13844,7 @@
   {
     "toaq": "ruaılıqfu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a princess.",
     "gloss": "princess",
     "short": "",
@@ -12949,6 +13858,7 @@
   {
     "toaq": "ruaınaqfu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a prince.",
     "gloss": "prince",
     "short": "",
@@ -12962,6 +13872,7 @@
   {
     "toaq": "ruao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ forgives ▯ for satisfying property ▯.",
     "gloss": "forgive",
     "short": "",
@@ -12975,6 +13886,7 @@
   {
     "toaq": "ruı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is gray.",
     "gloss": "gray",
     "short": "",
@@ -12988,6 +13900,7 @@
   {
     "toaq": "ruo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ behaves in way ▯ (property); ▯ conducts themselves in manner ▯ (property).",
     "gloss": "behave",
     "short": "",
@@ -13001,6 +13914,7 @@
   {
     "toaq": "ruogı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is well-behaved/good/nice.",
     "gloss": "kind",
     "short": "",
@@ -13014,6 +13928,7 @@
   {
     "toaq": "ruoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is straight/linear.",
     "gloss": "straight",
     "short": "",
@@ -13027,6 +13942,7 @@
   {
     "toaq": "ruoı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is thin.",
     "gloss": "thin",
     "short": "",
@@ -13040,6 +13956,7 @@
   {
     "toaq": "rue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is weak/feeble.",
     "gloss": "weak",
     "short": "",
@@ -13053,6 +13970,7 @@
   {
     "toaq": "rueq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is tight.",
     "gloss": "tight",
     "short": "",
@@ -13066,6 +13984,7 @@
   {
     "toaq": "rıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is green.",
     "gloss": "green",
     "short": "",
@@ -13079,6 +13998,7 @@
   {
     "toaq": "rıqchaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a Thursday.",
     "gloss": "thursday",
     "short": "",
@@ -13092,6 +14012,7 @@
   {
     "toaq": "rıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is open.",
     "gloss": "open",
     "short": "",
@@ -13105,6 +14026,7 @@
   {
     "toaq": "rıaq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a place/site; ▯ is the place/site of ▯.",
     "gloss": "place",
     "short": "",
@@ -13118,6 +14040,7 @@
   {
     "toaq": "rıaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ supports ▯; ▯ holds up ▯.",
     "gloss": "support",
     "short": "",
@@ -13131,6 +14054,7 @@
   {
     "toaq": "rıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a twilight/dawn/dusk/half-light/glimmering.",
     "gloss": "twilight",
     "short": "",
@@ -13144,6 +14068,7 @@
   {
     "toaq": "rıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ returns to satisfying property ▯.",
     "gloss": "return",
     "short": "",
@@ -13157,6 +14082,7 @@
   {
     "toaq": "rıubeaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a boomerang.",
     "gloss": "boomerang",
     "short": "",
@@ -13170,6 +14096,7 @@
   {
     "toaq": "rıudoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ returns ▯ to ▯; ▯ gives property ▯ back to ▯.",
     "gloss": "give.back",
     "short": "",
@@ -13183,6 +14110,7 @@
   {
     "toaq": "rıufa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ returns to ▯; ▯ goes back to ▯.",
     "gloss": "return",
     "short": "",
@@ -13196,6 +14124,7 @@
   {
     "toaq": "rıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is air.",
     "gloss": "air",
     "short": "",
@@ -13209,6 +14138,7 @@
   {
     "toaq": "rıochao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an aircraft/plane.",
     "gloss": "aircraft",
     "short": "",
@@ -13222,6 +14152,7 @@
   {
     "toaq": "rıofa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ flies; ▯ flies to ▯ from ▯.",
     "gloss": "fly",
     "short": "",
@@ -13235,6 +14166,7 @@
   {
     "toaq": "rıoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a type/kind of ▯",
     "gloss": "type",
     "short": "",
@@ -13248,6 +14180,7 @@
   {
     "toaq": "rıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is between/amidst/among ▯ (plural).",
     "gloss": "between",
     "short": "",
@@ -13261,6 +14194,7 @@
   {
     "toaq": "rıeq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ avoids/evades satisfying property ▯.",
     "gloss": "avoid",
     "short": "",
@@ -13284,6 +14218,7 @@
   {
     "toaq": "roq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ cries/weeps; ▯ cries tears ▯.",
     "gloss": "weep",
     "short": "",
@@ -13297,6 +14232,7 @@
   {
     "toaq": "roqdıao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tear/teardrop.",
     "gloss": "tear",
     "short": "",
@@ -13310,6 +14246,7 @@
   {
     "toaq": "roa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is natural.",
     "gloss": "natural",
     "short": "",
@@ -13328,6 +14265,7 @@
   {
     "toaq": "roajıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is nature.",
     "gloss": "nature",
     "short": "",
@@ -13341,6 +14279,7 @@
   {
     "toaq": "roaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a biological parent of ▯.",
     "gloss": "parent",
     "short": "",
@@ -13354,6 +14293,7 @@
   {
     "toaq": "roaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are eight in number.",
     "gloss": "eight",
     "short": "",
@@ -13367,6 +14307,7 @@
   {
     "toaq": "roaıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is eighth among ▯.",
     "gloss": "eighth",
     "short": "",
@@ -13403,6 +14344,7 @@
   {
     "toaq": "roe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is healthy.",
     "gloss": "healthy",
     "short": "",
@@ -13416,6 +14358,7 @@
   {
     "toaq": "roesho",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ recovers; ▯ becomes healthy.",
     "gloss": "recover",
     "short": "",
@@ -13429,6 +14372,7 @@
   {
     "toaq": "req",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a human.",
     "gloss": "human",
     "short": "",
@@ -13442,6 +14386,7 @@
   {
     "toaq": "rea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a border/edge of ▯.",
     "gloss": "border",
     "short": "",
@@ -13455,6 +14400,7 @@
   {
     "toaq": "reaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lies on ▯; ▯ reclines on ▯.",
     "gloss": "lie",
     "short": "",
@@ -13468,6 +14414,7 @@
   {
     "toaq": "reı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is around ▯; ▯ surrounds ▯.",
     "gloss": "around",
     "short": "",
@@ -13481,6 +14428,7 @@
   {
     "toaq": "reo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is coloured; ▯ is of colour ▯.",
     "gloss": "coloured",
     "short": "",
@@ -13503,6 +14451,7 @@
   {
     "toaq": "reosıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is colourless.",
     "gloss": "colourless",
     "short": "",
@@ -13516,6 +14465,7 @@
   {
     "toaq": "reoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is late.",
     "gloss": "late",
     "short": "",
@@ -13529,6 +14479,7 @@
   {
     "toaq": "reoqhaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is dinner (late/evening meal).",
     "gloss": "dinner",
     "short": "",
@@ -13542,6 +14493,7 @@
   {
     "toaq": "reoqrıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is dusk.",
     "gloss": "dusk",
     "short": "",
@@ -13578,6 +14530,7 @@
   {
     "toaq": "sabaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is soap.",
     "gloss": "soap",
     "short": "",
@@ -13591,6 +14544,7 @@
   {
     "toaq": "saralıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is Australia.",
     "gloss": "Australia",
     "short": "",
@@ -13604,6 +14558,7 @@
   {
     "toaq": "saq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are three in number.",
     "gloss": "three",
     "short": "",
@@ -13617,6 +14572,7 @@
   {
     "toaq": "saqchıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens thrice / three times.",
     "gloss": "thrice",
     "short": "",
@@ -13630,6 +14586,7 @@
   {
     "toaq": "saqko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is third among ▯.",
     "gloss": "third",
     "short": "",
@@ -13643,6 +14600,7 @@
   {
     "toaq": "saqlıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a triplet.",
     "gloss": "triplet",
     "short": "",
@@ -13656,6 +14614,7 @@
   {
     "toaq": "saqsıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tricycle.",
     "gloss": "tricycle",
     "short": "",
@@ -13669,6 +14628,7 @@
   {
     "toaq": "saqseoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter S.",
     "gloss": "S",
     "short": "",
@@ -13682,6 +14642,7 @@
   {
     "toaq": "saı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is matter/material/substance.",
     "gloss": "matter",
     "short": "",
@@ -13695,6 +14656,7 @@
   {
     "toaq": "sao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is big/large.",
     "gloss": "big",
     "short": "",
@@ -13708,6 +14670,7 @@
   {
     "toaq": "saodoaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a city.",
     "gloss": "city",
     "short": "",
@@ -13721,6 +14684,7 @@
   {
     "toaq": "saojeaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ grows / gets bigger.",
     "gloss": "grow",
     "short": "",
@@ -13734,6 +14698,7 @@
   {
     "toaq": "su",
     "type": "predicate",
+    "animacy": "?",
     "english": "▯ are [previous predicate].",
     "gloss": "previous.predicate",
     "short": "",
@@ -13747,6 +14712,7 @@
   {
     "toaq": "suhu",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a pig.",
     "gloss": "pig",
     "short": "",
@@ -13760,6 +14726,7 @@
   {
     "toaq": "sushı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is sushi.",
     "gloss": "sushi",
     "short": "",
@@ -13786,6 +14753,7 @@
   {
     "toaq": "suqbo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is yours.",
     "gloss": "your",
     "short": "",
@@ -13799,6 +14767,7 @@
   {
     "toaq": "suqjı",
     "type": "predicate",
+    "animacy": "fuy",
     "english": "▯ is us (we, the speaker and the listener(s)).",
     "gloss": "we",
     "short": "",
@@ -13812,6 +14781,7 @@
   {
     "toaq": "sua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is necessary for ▯ to happen.",
     "gloss": "necessary",
     "short": "",
@@ -13825,6 +14795,7 @@
   {
     "toaq": "suahuaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is superfluous / more than is necessary for ▯ to happen.",
     "gloss": "superfluous",
     "short": "",
@@ -13838,6 +14809,7 @@
   {
     "toaq": "suaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ sings.",
     "gloss": "sing",
     "short": "",
@@ -13851,6 +14823,7 @@
   {
     "toaq": "suaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is fast/quick; ▯ quickly does ▯.",
     "gloss": "fast",
     "short": "",
@@ -13864,6 +14837,7 @@
   {
     "toaq": "suaıkuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is in a hurry; ▯ feels the urge to quickly satisfy property ▯.",
     "gloss": "in.a.hurry",
     "short": "",
@@ -13877,6 +14851,7 @@
   {
     "toaq": "suao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is important.",
     "gloss": "important",
     "short": "",
@@ -13890,6 +14865,7 @@
   {
     "toaq": "suaojıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ cares about ▯; ▯ considers ▯ important.",
     "gloss": "care",
     "short": "",
@@ -13903,6 +14879,7 @@
   {
     "toaq": "suı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is least in property ▯ among ▯.",
     "gloss": "least",
     "short": "",
@@ -13929,6 +14906,7 @@
   {
     "toaq": "suobo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is yours (2nd + 3rd person).",
     "gloss": "our",
     "short": "",
@@ -13942,6 +14920,7 @@
   {
     "toaq": "sue",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ asks ▯ to satisfy property ▯.",
     "gloss": "request",
     "short": "",
@@ -13955,6 +14934,7 @@
   {
     "toaq": "sueta",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sweater.",
     "gloss": "sweater",
     "short": "",
@@ -13968,6 +14948,7 @@
   {
     "toaq": "suy",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a wave.",
     "gloss": "wave",
     "short": "",
@@ -13981,6 +14962,7 @@
   {
     "toaq": "sha",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ arrives at satisfying property ▯.",
     "gloss": "arrive",
     "short": "",
@@ -13994,6 +14976,7 @@
   {
     "toaq": "shaha",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is chess.",
     "gloss": "chess",
     "short": "",
@@ -14007,6 +14990,7 @@
   {
     "toaq": "shamu",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is an apple.",
     "gloss": "apple",
     "short": "",
@@ -14020,6 +15004,7 @@
   {
     "toaq": "shatı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a shirt.",
     "gloss": "shirt",
     "short": "",
@@ -14033,6 +15018,7 @@
   {
     "toaq": "shaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is in front of ▯.",
     "gloss": "in.front",
     "short": "",
@@ -14046,6 +15032,7 @@
   {
     "toaq": "shaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ ceases to be the case; ▯ stops satisfying property ▯; ▯ loses property ▯.",
     "gloss": "cease",
     "short": "",
@@ -14059,6 +15046,7 @@
   {
     "toaq": "shao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ wants ▯ to be the case.",
     "gloss": "want",
     "short": "",
@@ -14072,6 +15060,7 @@
   {
     "toaq": "shaogı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is good/virtuous.",
     "gloss": "good",
     "short": "",
@@ -14085,6 +15074,7 @@
   {
     "toaq": "shaohuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is bad/evil/wicked.",
     "gloss": "bad",
     "short": "",
@@ -14111,6 +15101,7 @@
   {
     "toaq": "shua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ falls to ▯ from ▯.",
     "gloss": "fall",
     "short": "",
@@ -14124,6 +15115,7 @@
   {
     "toaq": "shuacao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an autumn/fall.",
     "gloss": "autumn",
     "short": "",
@@ -14137,6 +15129,7 @@
   {
     "toaq": "shuaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ produces ▯.",
     "gloss": "produce",
     "short": "",
@@ -14150,6 +15143,7 @@
   {
     "toaq": "shuaqjıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a factory.",
     "gloss": "factory",
     "short": "",
@@ -14163,6 +15157,7 @@
   {
     "toaq": "shuaqse",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a product.",
     "gloss": "product",
     "short": "",
@@ -14176,6 +15171,7 @@
   {
     "toaq": "shuaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is simple.",
     "gloss": "simple",
     "short": "",
@@ -14189,6 +15185,7 @@
   {
     "toaq": "shuao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a bird.",
     "gloss": "bird",
     "short": "",
@@ -14202,6 +15199,7 @@
   {
     "toaq": "shuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is secret.",
     "gloss": "secret",
     "short": "",
@@ -14215,6 +15213,7 @@
   {
     "toaq": "shuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a source/deposit/supply/reserve of ▯.",
     "gloss": "reserve",
     "short": "",
@@ -14228,6 +15227,7 @@
   {
     "toaq": "shue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ remains/stays/keeps satisfying property ▯.",
     "gloss": "remain",
     "short": "",
@@ -14241,6 +15241,7 @@
   {
     "toaq": "shueq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is bitter.",
     "gloss": "bitter",
     "short": "",
@@ -14254,6 +15255,7 @@
   {
     "toaq": "shı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is one in number.",
     "gloss": "one",
     "short": "",
@@ -14267,6 +15269,7 @@
   {
     "toaq": "shıchıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ happens once / one time.",
     "gloss": "once",
     "short": "",
@@ -14280,6 +15283,7 @@
   {
     "toaq": "shıho",
     "type": "predicate",
+    "animacy": "fuy",
     "english": "▯ is him/her (singular).",
     "gloss": "he/she",
     "short": "",
@@ -14293,6 +15297,7 @@
   {
     "toaq": "shıko",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is first among ▯.",
     "gloss": "first",
     "short": "",
@@ -14306,6 +15311,7 @@
   {
     "toaq": "shıraı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is an individual.",
     "gloss": "individual",
     "short": "",
@@ -14319,6 +15325,7 @@
   {
     "toaq": "shıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is olfactory; ▯ pertains to the sense of smell/olfaction.",
     "gloss": "smell",
     "short": "",
@@ -14332,6 +15339,7 @@
   {
     "toaq": "shıqgaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ smells state of affairs ▯.",
     "gloss": "smell",
     "short": "",
@@ -14345,6 +15353,7 @@
   {
     "toaq": "shıqhua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a nose.",
     "gloss": "nose",
     "short": "",
@@ -14358,6 +15367,7 @@
   {
     "toaq": "shıa",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is glass.",
     "gloss": "glass",
     "short": "",
@@ -14371,6 +15381,7 @@
   {
     "toaq": "shıabıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a glass (container).",
     "gloss": "glass",
     "short": "",
@@ -14384,6 +15395,7 @@
   {
     "toaq": "shıapoaqse",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a glass shard; ▯ is a piece of broken glass.",
     "gloss": "glass.shard",
     "short": "",
@@ -14397,6 +15409,7 @@
   {
     "toaq": "shıaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a leg.",
     "gloss": "leg",
     "short": "",
@@ -14410,6 +15423,7 @@
   {
     "toaq": "shıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is before / in the past of ▯.",
     "gloss": "before",
     "short": "",
@@ -14423,6 +15437,7 @@
   {
     "toaq": "shıujaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ looks forward to ▯; ▯ is in joyful anticipation of ▯.",
     "gloss": "look.forward",
     "short": "",
@@ -14436,6 +15451,7 @@
   {
     "toaq": "shıukune",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a racoon; ▯ is a member of genus Procyon.",
     "gloss": "raccoon",
     "short": "",
@@ -14449,6 +15465,7 @@
   {
     "toaq": "shıume",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a/the past.",
     "gloss": "past",
     "short": "",
@@ -14462,6 +15479,7 @@
   {
     "toaq": "shıumejıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a museum.",
     "gloss": "museum",
     "short": "",
@@ -14475,6 +15493,7 @@
   {
     "toaq": "shıo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a hip/shoulder.",
     "gloss": "ball.joint",
     "short": "",
@@ -14488,6 +15507,7 @@
   {
     "toaq": "shıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is awake.",
     "gloss": "awake",
     "short": "",
@@ -14501,6 +15521,7 @@
   {
     "toaq": "shıesho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ wakes up.",
     "gloss": "wake.up",
     "short": "",
@@ -14514,6 +15535,7 @@
   {
     "toaq": "shıy",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ disappears / leaves perception.",
     "gloss": "disappear",
     "short": "",
@@ -14527,6 +15549,7 @@
   {
     "toaq": "sho",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ becomes such that they satisfy property ▯.",
     "gloss": "become",
     "short": "",
@@ -14540,6 +15563,7 @@
   {
     "toaq": "shoshıa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Sh.",
     "gloss": "Sh",
     "short": "",
@@ -14553,6 +15577,7 @@
   {
     "toaq": "shoa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is deep.",
     "gloss": "deep",
     "short": "",
@@ -14566,6 +15591,7 @@
   {
     "toaq": "shoaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a wing.",
     "gloss": "wing",
     "short": "",
@@ -14589,6 +15615,7 @@
   {
     "toaq": "shoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ screams/shouts/yells/cries.",
     "gloss": "scream",
     "short": "",
@@ -14602,6 +15629,7 @@
   {
     "toaq": "shoe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ lets ▯ happen; ▯ allows ▯ to happen.",
     "gloss": "allow",
     "short": "",
@@ -14615,6 +15643,7 @@
   {
     "toaq": "she",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the case if ▯ is the case.",
     "gloss": "if",
     "short": "",
@@ -14628,6 +15657,7 @@
   {
     "toaq": "shea",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is empty in aspect ▯.",
     "gloss": "empty",
     "short": "",
@@ -14641,6 +15671,7 @@
   {
     "toaq": "sheaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ stands on ▯.",
     "gloss": "stand",
     "short": "",
@@ -14654,6 +15685,7 @@
   {
     "toaq": "sheı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is free to do ▯.",
     "gloss": "free",
     "short": "",
@@ -14667,6 +15699,7 @@
   {
     "toaq": "sheo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ regrets satisfying property ▯.",
     "gloss": "regret",
     "short": "",
@@ -14680,6 +15713,7 @@
   {
     "toaq": "sheokuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ says sorry to ▯.",
     "gloss": "apologize",
     "short": "",
@@ -14693,6 +15727,7 @@
   {
     "toaq": "sı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is attentive to / focuses on ▯.",
     "gloss": "attentive",
     "short": "",
@@ -14706,6 +15741,7 @@
   {
     "toaq": "sıdı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a CD.",
     "gloss": "CD",
     "short": "",
@@ -14719,6 +15755,7 @@
   {
     "toaq": "sıga",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a cigarette.",
     "gloss": "cigarette",
     "short": "",
@@ -14732,6 +15769,7 @@
   {
     "toaq": "sımı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a monkey.",
     "gloss": "monkey",
     "short": "",
@@ -14745,6 +15783,7 @@
   {
     "toaq": "sımo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a simian.",
     "gloss": "simian",
     "short": "",
@@ -14758,6 +15797,7 @@
   {
     "toaq": "sıq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is clean/pure.",
     "gloss": "clean",
     "short": "",
@@ -14771,6 +15811,7 @@
   {
     "toaq": "sıqkea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a washing machine.",
     "gloss": "washing.machine",
     "short": "",
@@ -14803,6 +15844,7 @@
   {
     "toaq": "sıachoa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ says nothing / is silent.",
     "gloss": "say.nothing",
     "short": "",
@@ -14816,6 +15858,7 @@
   {
     "toaq": "sıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is to the right of ▯.",
     "gloss": "right",
     "short": "",
@@ -14829,6 +15872,7 @@
   {
     "toaq": "sıaqcu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ moves rightwards.",
     "gloss": "rightwards",
     "short": "",
@@ -14842,6 +15886,7 @@
   {
     "toaq": "sıaqpaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the right part of ▯.",
     "gloss": "right",
     "short": "",
@@ -14855,6 +15900,7 @@
   {
     "toaq": "sıaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is blood.",
     "gloss": "blood",
     "short": "",
@@ -14868,6 +15914,7 @@
   {
     "toaq": "sıao",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a beginning/start; ▯ is a beginning/start of ▯.",
     "gloss": "beginning",
     "short": "",
@@ -14881,6 +15928,7 @@
   {
     "toaq": "sıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is similar to ▯.",
     "gloss": "similar",
     "short": "",
@@ -14894,6 +15942,7 @@
   {
     "toaq": "sıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a thought/idea.",
     "gloss": "thought",
     "short": "",
@@ -14907,6 +15956,7 @@
   {
     "toaq": "sıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a wheel.",
     "gloss": "wheel",
     "short": "",
@@ -14920,6 +15970,7 @@
   {
     "toaq": "sıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is following to ▯ in sequence ▯.",
     "gloss": "follow",
     "short": "",
@@ -14933,6 +15984,7 @@
   {
     "toaq": "sıefa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ follows/goes after ▯.",
     "gloss": "follow",
     "short": "",
@@ -14946,6 +15998,7 @@
   {
     "toaq": "sıeq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ feels awe; ▯ is amazed.",
     "gloss": "awe",
     "short": "",
@@ -14959,6 +16012,7 @@
   {
     "toaq": "sıeqca",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is amazing.",
     "gloss": "amazing",
     "short": "",
@@ -14972,6 +16026,7 @@
   {
     "toaq": "soka",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is soccer/football.",
     "gloss": "soccer",
     "short": "",
@@ -14985,6 +16040,7 @@
   {
     "toaq": "soq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the ▯est among ▯; ▯ is the most ▯ among ▯.",
     "gloss": "most",
     "short": "",
@@ -14999,6 +16055,7 @@
   {
     "toaq": "soq gỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the best among ▯.",
     "gloss": "best",
     "short": "",
@@ -15012,6 +16069,7 @@
   {
     "toaq": "soq hủı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the worst among ▯.",
     "gloss": "worst",
     "short": "",
@@ -15025,6 +16083,7 @@
   {
     "toaq": "soq nủı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the smallest among ▯.",
     "gloss": "smallest",
     "short": "",
@@ -15038,6 +16097,7 @@
   {
     "toaq": "soq pủı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are the most numerous among ▯.",
     "gloss": "most",
     "short": "",
@@ -15051,6 +16111,7 @@
   {
     "toaq": "soq sảo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is the biggest among ▯.",
     "gloss": "biggest",
     "short": "",
@@ -15064,6 +16125,7 @@
   {
     "toaq": "soa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ helps ▯ to satisfy property ▯.",
     "gloss": "help",
     "short": "",
@@ -15077,6 +16139,7 @@
   {
     "toaq": "soaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a garden.",
     "gloss": "garden",
     "short": "",
@@ -15090,6 +16153,7 @@
   {
     "toaq": "soaqche",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a gardener.",
     "gloss": "gardener",
     "short": "",
@@ -15103,6 +16167,7 @@
   {
     "toaq": "soaı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a beam/ray/line extending outwards from a point.",
     "gloss": "beam",
     "short": "",
@@ -15116,6 +16181,7 @@
   {
     "toaq": "soı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ fights with ▯; ▯ fights against ▯.",
     "gloss": "fight",
     "short": "",
@@ -15129,6 +16195,7 @@
   {
     "toaq": "soe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is sour.",
     "gloss": "sour",
     "short": "",
@@ -15142,6 +16209,7 @@
   {
     "toaq": "se",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a result/product of performing action ▯.",
     "gloss": "result",
     "short": "",
@@ -15155,6 +16223,7 @@
   {
     "toaq": "sekuq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a second.",
     "gloss": "second",
     "short": "",
@@ -15168,6 +16237,7 @@
   {
     "toaq": "seta",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>21</sup> (1,000,000,000,000,000,000,000) in number; ▯ are a sextillion.",
     "gloss": "zetta",
     "short": "",
@@ -15181,6 +16251,7 @@
   {
     "toaq": "sea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ rests/relaxes.",
     "gloss": "rest",
     "short": "",
@@ -15194,6 +16265,7 @@
   {
     "toaq": "seakuaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is exhausted.",
     "gloss": "exhausted",
     "short": "",
@@ -15207,6 +16279,7 @@
   {
     "toaq": "seaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ has sex with ▯; ▯ has sexual intercourse with ▯.",
     "gloss": "have.sex",
     "short": "",
@@ -15218,8 +16291,9 @@
     "fields": []
   },
   {
-    "toaq": "seu",
+    "toaq": "sey",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a number.",
     "gloss": "number",
     "short": "",
@@ -15233,6 +16307,7 @@
   {
     "toaq": "seo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a spouse of ▯.",
     "gloss": "spouse",
     "short": "",
@@ -15246,6 +16321,7 @@
   {
     "toaq": "seoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a sky.",
     "gloss": "sky",
     "short": "",
@@ -15259,6 +16335,7 @@
   {
     "toaq": "seoqrea",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a horizon.",
     "gloss": "horizon",
     "short": "",
@@ -15272,6 +16349,7 @@
   {
     "toaq": "seoqtue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is weather; ▯ is the state of the weather.",
     "gloss": "weather",
     "short": "",
@@ -15307,6 +16385,7 @@
   {
     "toaq": "tama",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tomato.",
     "gloss": "tomato",
     "short": "",
@@ -15320,6 +16399,7 @@
   {
     "toaq": "taq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is related to itself by property ▯.",
     "gloss": "self",
     "short": "",
@@ -15333,6 +16413,7 @@
   {
     "toaq": "taqchao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a car; ▯ is an automobile.",
     "gloss": "car",
     "short": "",
@@ -15346,6 +16427,7 @@
   {
     "toaq": "taq tủa mủaq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ commits suicide / kills themselves.",
     "gloss": "commit.suicide",
     "short": "",
@@ -15359,6 +16441,7 @@
   {
     "toaq": "taı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ succeeds at satisfying property ▯.",
     "gloss": "succeed",
     "short": "",
@@ -15372,6 +16455,7 @@
   {
     "toaq": "tao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ does ▯.",
     "gloss": "do",
     "short": "",
@@ -15385,11 +16469,12 @@
   {
     "toaq": "taocıa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is accidental/unintentional.",
     "gloss": "accidental",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "notes": [],
     "examples": [],
@@ -15398,6 +16483,7 @@
   {
     "toaq": "taodıe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ advises ▯ to do ▯.",
     "gloss": "advise",
     "short": "",
@@ -15411,6 +16497,7 @@
   {
     "toaq": "taokoe",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ chooses to do ▯.",
     "gloss": "choose.to",
     "short": "",
@@ -15424,6 +16511,7 @@
   {
     "toaq": "taomoı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ considers doing ▯.",
     "gloss": "consider.doing",
     "short": "",
@@ -15437,6 +16525,7 @@
   {
     "toaq": "taosıo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is an idea/plan.",
     "gloss": "plan",
     "short": "",
@@ -15469,6 +16558,7 @@
   {
     "toaq": "tuchao",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bus/omnibus.",
     "gloss": "bus",
     "short": "",
@@ -15482,6 +16572,7 @@
   {
     "toaq": "tuchaoce",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bus stop.",
     "gloss": "bus.stop",
     "short": "",
@@ -15515,6 +16606,7 @@
   {
     "toaq": "tuqfıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is first in sequence ▯.",
     "gloss": "first",
     "short": "",
@@ -15528,6 +16620,7 @@
   {
     "toaq": "tuqsıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is last in sequence ▯.",
     "gloss": "last",
     "short": "",
@@ -15541,6 +16634,7 @@
   {
     "toaq": "tua",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ makes ▯ happen.",
     "gloss": "make.happen",
     "short": "",
@@ -15554,6 +16648,7 @@
   {
     "toaq": "tua bủo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ prepares ▯ for satisfying property ▯.",
     "gloss": "prepare",
     "short": "",
@@ -15567,6 +16662,7 @@
   {
     "toaq": "tua dủa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ tells ▯ that ▯ is the case; ▯ makes ▯ know ▯.",
     "gloss": "tell",
     "short": "",
@@ -15580,6 +16676,7 @@
   {
     "toaq": "tua dỉa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lowers ▯ in how much it satisfies property ▯.",
     "gloss": "lower",
     "short": "",
@@ -15593,6 +16690,7 @@
   {
     "toaq": "tua gảı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ shows ▯ state of affairs ▯; ▯ makes ▯ observe ▯.",
     "gloss": "show",
     "short": "",
@@ -15606,6 +16704,7 @@
   {
     "toaq": "tua hỏaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ ignites ▯; ▯ sets fire to ▯.",
     "gloss": "ignite",
     "short": "",
@@ -15619,6 +16718,7 @@
   {
     "toaq": "tua jẻaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ raises ▯ in how much it satisfies property ▯.",
     "gloss": "raise",
     "short": "",
@@ -15632,6 +16732,7 @@
   {
     "toaq": "tua jẻaq gẻa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ raises ▯.",
     "gloss": "raise",
     "short": "",
@@ -15645,6 +16746,7 @@
   {
     "toaq": "tua jẻaq nỉa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ lowers ▯.",
     "gloss": "lower",
     "short": "",
@@ -15658,6 +16760,7 @@
   {
     "toaq": "tua kảqgaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ shows ▯ state of affairs ▯; ▯ makes ▯ see ▯.",
     "gloss": "show",
     "short": "",
@@ -15671,6 +16774,7 @@
   {
     "toaq": "tua nỉe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ puts ▯ inside ▯.",
     "gloss": "put.inside",
     "short": "",
@@ -15684,6 +16788,7 @@
   {
     "toaq": "tua nẻo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ puts ▯ onto ▯.",
     "gloss": "put.onto",
     "short": "",
@@ -15697,6 +16802,7 @@
   {
     "toaq": "tua pỏaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ breaks/splits/separates ▯.",
     "gloss": "split",
     "short": "",
@@ -15710,6 +16816,7 @@
   {
     "toaq": "tua shỉe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ wakes ▯ up; ▯ awakens ▯.",
     "gloss": "wake",
     "short": "",
@@ -15723,6 +16830,7 @@
   {
     "toaq": "tua tỉ",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ puts ▯ at ▯.",
     "gloss": "put",
     "short": "",
@@ -15736,6 +16844,7 @@
   {
     "toaq": "tua tỉrıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ puts ▯ back at ▯.",
     "gloss": "put.back",
     "short": "",
@@ -15749,6 +16858,7 @@
   {
     "toaq": "tua zủy",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ breaks/destroys ▯; ▯ makes ▯ broken/inoperable.",
     "gloss": "break",
     "short": "",
@@ -15762,6 +16872,7 @@
   {
     "toaq": "tuaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a body/corpse.",
     "gloss": "body",
     "short": "",
@@ -15775,6 +16886,7 @@
   {
     "toaq": "tuaıbo",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is physical/corporal.",
     "gloss": "physical",
     "short": "",
@@ -15788,6 +16900,7 @@
   {
     "toaq": "tuaıcıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is non-physical.",
     "gloss": "non-physical",
     "short": "",
@@ -15801,6 +16914,7 @@
   {
     "toaq": "tuao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a little bit the case; ▯ is little/non-much in property ▯.",
     "gloss": "little",
     "short": "",
@@ -15814,6 +16928,7 @@
   {
     "toaq": "tuaobu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is quite ▯.",
     "gloss": "quite",
     "short": "",
@@ -15827,6 +16942,7 @@
   {
     "toaq": "tuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ sits on ▯.",
     "gloss": "sit",
     "short": "",
@@ -15840,6 +16956,7 @@
   {
     "toaq": "tuımy",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a seat/chair/stool/bench.",
     "gloss": "seat",
     "short": "",
@@ -15853,6 +16970,7 @@
   {
     "toaq": "tuıtoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bench.",
     "gloss": "bench",
     "short": "",
@@ -15866,6 +16984,7 @@
   {
     "toaq": "tuo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ swallows; ▯ swallows ▯.",
     "gloss": "swallow",
     "short": "",
@@ -15879,6 +16998,7 @@
   {
     "toaq": "tuoq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is heavy.",
     "gloss": "heavy",
     "short": "",
@@ -15892,6 +17012,7 @@
   {
     "toaq": "tuoı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a flaw/fault/defect in ▯.",
     "gloss": "flaw",
     "short": "",
@@ -15905,6 +17026,7 @@
   {
     "toaq": "tuoıcıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is flawless/perfect.",
     "gloss": "flawless",
     "short": "",
@@ -15918,6 +17040,7 @@
   {
     "toaq": "tue",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a state / state of affairs / situation; ▯ is a state of affairs of property ▯.",
     "gloss": "state",
     "short": "",
@@ -15931,6 +17054,7 @@
   {
     "toaq": "tı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is at ▯.",
     "gloss": "at",
     "short": "",
@@ -15944,6 +17068,7 @@
   {
     "toaq": "tıbumeo",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ misses ▯; ▯ is sad that ▯ is not there.",
     "gloss": "miss",
     "short": "",
@@ -15957,6 +17082,7 @@
   {
     "toaq": "tıbı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ pertains to television.",
     "gloss": "TV",
     "short": "",
@@ -15970,6 +17096,7 @@
   {
     "toaq": "tıduasho",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ finds ▯; ▯ discovers that ▯ is at ▯.",
     "gloss": "find",
     "short": "",
@@ -15983,6 +17110,7 @@
   {
     "toaq": "tıjao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is far away from ▯.",
     "gloss": "far",
     "short": "",
@@ -15996,6 +17124,7 @@
   {
     "toaq": "tıjuı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is near / in the vicinity of ▯.",
     "gloss": "near",
     "short": "",
@@ -16009,6 +17138,7 @@
   {
     "toaq": "tınıqdua",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ finds ▯; ▯ discovers that ▯ is at ▯.",
     "gloss": "find",
     "short": "",
@@ -16022,6 +17152,7 @@
   {
     "toaq": "tırıu",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ returns to location ▯.",
     "gloss": "return",
     "short": "",
@@ -16035,6 +17166,7 @@
   {
     "toaq": "tısha",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ arrives at ▯.",
     "gloss": "arrive",
     "short": "",
@@ -16048,6 +17180,7 @@
   {
     "toaq": "tıshue",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ stays at ▯.",
     "gloss": "stay",
     "short": "",
@@ -16061,6 +17194,7 @@
   {
     "toaq": "tıse",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a trace/remnant of ▯.",
     "gloss": "trace",
     "short": "",
@@ -16074,6 +17208,7 @@
   {
     "toaq": "tıtıeq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter T.",
     "gloss": "T",
     "short": "",
@@ -16087,6 +17222,7 @@
   {
     "toaq": "tıq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a tile.",
     "gloss": "tile",
     "short": "",
@@ -16100,6 +17236,7 @@
   {
     "toaq": "tıqshoaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a butterfly/moth.",
     "gloss": "butterfly",
     "short": "",
@@ -16119,6 +17256,7 @@
   {
     "toaq": "tıa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is behind ▯.",
     "gloss": "behind",
     "short": "",
@@ -16132,6 +17270,7 @@
   {
     "toaq": "tıaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is brown.",
     "gloss": "brown",
     "short": "",
@@ -16145,6 +17284,7 @@
   {
     "toaq": "tıaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a box.",
     "gloss": "box",
     "short": "",
@@ -16158,6 +17298,7 @@
   {
     "toaq": "tıao",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ matches/fits/suits ▯ in relation ▯.",
     "gloss": "match",
     "short": "",
@@ -16191,7 +17332,8 @@
   {
     "toaq": "tıopuı",
     "type": "predicate",
-    "english": "▯ are how many.",
+    "animacy": "ta",
+    "english": "▯ are how many?",
     "gloss": "how.many",
     "short": "",
     "keywords": [],
@@ -16204,6 +17346,7 @@
   {
     "toaq": "tıoq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lock.",
     "gloss": "lock",
     "short": "",
@@ -16217,6 +17360,7 @@
   {
     "toaq": "tıoqpoa",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is locked.",
     "gloss": "locked",
     "short": "",
@@ -16230,6 +17374,7 @@
   {
     "toaq": "tıe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ covers ▯.",
     "gloss": "cover",
     "short": "",
@@ -16243,6 +17388,7 @@
   {
     "toaq": "tıechuo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a lid/cover.",
     "gloss": "lid",
     "short": "",
@@ -16256,6 +17402,7 @@
   {
     "toaq": "tıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a way/path.",
     "gloss": "path",
     "short": "",
@@ -16279,6 +17426,7 @@
   {
     "toaq": "toq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a board.",
     "gloss": "board",
     "short": "",
@@ -16292,6 +17440,7 @@
   {
     "toaq": "toqfua",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a table.",
     "gloss": "table",
     "short": "",
@@ -16305,6 +17454,7 @@
   {
     "toaq": "toa",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a word.",
     "gloss": "word",
     "short": "",
@@ -16318,6 +17468,7 @@
   {
     "toaq": "toagıu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a line (of text).",
     "gloss": "line",
     "short": "",
@@ -16331,6 +17482,7 @@
   {
     "toaq": "toaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is Toaqic; ▯ is of or pertaining to Toaq.",
     "gloss": "Toaqic",
     "short": "",
@@ -16344,6 +17496,7 @@
   {
     "toaq": "Toaqzu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the Toaq language.",
     "gloss": "language",
     "short": "",
@@ -16357,6 +17510,7 @@
   {
     "toaq": "toaı",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is a quantum / smallest possible unit of quantity or quantifiable phenomenon ▯.",
     "gloss": "quantum",
     "short": "",
@@ -16380,6 +17534,7 @@
   {
     "toaq": "toı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ does to ▯ relation ▯.",
     "gloss": "act.towards",
     "short": "",
@@ -16416,6 +17571,7 @@
   {
     "toaq": "toe",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ cuts ▯ into ▯.",
     "gloss": "cut",
     "short": "",
@@ -16429,6 +17585,7 @@
   {
     "toaq": "toemy",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a knife.",
     "gloss": "knife",
     "short": "",
@@ -16442,6 +17599,7 @@
   {
     "toaq": "te",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ has been ▯-ed (property).",
     "gloss": "-ed",
     "short": "",
@@ -16464,6 +17622,7 @@
   {
     "toaq": "tera",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ are 10<sup>12</sup> (1,000,000,000,000) in number; ▯ are a trillion.",
     "gloss": "tera",
     "short": "",
@@ -16477,6 +17636,7 @@
   {
     "toaq": "teq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ pays ▯ to ▯ for satisfying property ▯.",
     "gloss": "pay",
     "short": "",
@@ -16491,6 +17651,7 @@
   {
     "toaq": "teqguaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ does paid work ▯; ▯ does ▯ as a job.",
     "gloss": "pay.work",
     "short": "",
@@ -16504,6 +17665,7 @@
   {
     "toaq": "tea",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is scared / experiences fear.",
     "gloss": "scared",
     "short": "",
@@ -16517,6 +17679,7 @@
   {
     "toaq": "teaq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a breast.",
     "gloss": "breast",
     "short": "",
@@ -16530,6 +17693,7 @@
   {
     "toaq": "teaqjıeq",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a nipple.",
     "gloss": "nipple",
     "short": "",
@@ -16543,6 +17707,7 @@
   {
     "toaq": "teaqnıaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is a mammal.",
     "gloss": "mammal",
     "short": "",
@@ -16556,6 +17721,7 @@
   {
     "toaq": "teaqrıaı",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a bra.",
     "gloss": "bra",
     "short": "",
@@ -16569,6 +17735,7 @@
   {
     "toaq": "teı",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a form/shape; ▯ is a form/shape of ▯.",
     "gloss": "form",
     "short": "",
@@ -16592,6 +17759,7 @@
   {
     "toaq": "teoq",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a question.",
     "gloss": "question",
     "short": "",
@@ -16607,6 +17775,7 @@
   {
     "toaq": "teoqkuq",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ asks question ▯ to ▯.",
     "gloss": "ask",
     "short": "",
@@ -16620,6 +17789,7 @@
   {
     "toaq": "za",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is about to be the case.",
     "gloss": "INCH",
     "short": "",
@@ -16633,6 +17803,7 @@
   {
     "toaq": "zaq",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ appears / enters perception.",
     "gloss": "appear",
     "short": "",
@@ -16646,6 +17817,7 @@
   {
     "toaq": "zaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ hopes that ▯ is the case.",
     "gloss": "hope",
     "short": "",
@@ -16659,6 +17831,7 @@
   {
     "toaq": "zao",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ knows / is familiar with ▯.",
     "gloss": "know",
     "short": "",
@@ -16672,6 +17845,7 @@
   {
     "toaq": "zu",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is a language.",
     "gloss": "language",
     "short": "",
@@ -16685,6 +17859,7 @@
   {
     "toaq": "zuy",
     "type": "predicate",
+    "animacy": "ta",
     "english": "▯ is broken/inoperable.",
     "gloss": "broken",
     "short": "",
@@ -16708,6 +17883,7 @@
   {
     "toaq": "zozeo",
     "type": "predicate",
+    "animacy": "hoq",
     "english": "▯ is the letter Z.",
     "gloss": "Z",
     "short": "",
@@ -16721,6 +17897,7 @@
   {
     "toaq": "zoaı",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ doubts that ▯ is the case.",
     "gloss": "doubt",
     "short": "",
@@ -16734,6 +17911,7 @@
   {
     "toaq": "zoaıcıa",
     "type": "predicate",
+    "animacy": "ho",
     "english": "▯ is certain that ▯ is the case.",
     "gloss": "certain",
     "short": "",
@@ -16760,6 +17938,7 @@
   {
     "toaq": "zeo",
     "type": "predicate",
+    "animacy": "maq",
     "english": "▯ is a fruit.",
     "gloss": "fruit",
     "short": "",


### PR DESCRIPTION
A few rules I went by in assigning these:

* Verbs that require the subject to think or be sentient are all `ho`.
* Words whose first slot is `0` or `1` are `hoq`, because events/properties are abstract.
* Non-sentient "nouns" are `maq` or `hoq`. The "tangible" distinction is a bit blurry, but I went with my gut feeling!
* Positional verbs are `ta`, because you can talk about the spatial location of non-tangible/imaginary points.
* When in doubt, I usually went with `ta`.

Regarding serials and "animacy strength": I think we should make animacy strength something that can be derived from animacy+frame. For example `ta(c)` (like **sao**) is weak, but `ta(c 0)` (like **se**) is strong.