### PR TITLE
sey → zıu

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -16442,20 +16442,6 @@
     "fields": []
   },
   {
-    "toaq": "sey",
-    "type": "predicate",
-    "english": "▯ is a number.",
-    "gloss": "number",
-    "short": "",
-    "keywords": [],
-    "frame": "a",
-    "distribution": "d",
-    "pronominal_class": "hoq",
-    "notes": [],
-    "examples": [],
-    "fields": []
-  },
-  {
     "toaq": "tá",
     "type": "pronoun",
     "english": "anaphoric pronoun for adjective DPs (class IV)",
@@ -17976,6 +17962,20 @@
     "keywords": [],
     "notes": [],
     "examples": []
+  },
+  {
+    "toaq": "zıu",
+    "type": "predicate",
+    "english": "▯ is a number.",
+    "gloss": "number",
+    "short": "",
+    "keywords": [],
+    "frame": "a",
+    "distribution": "d",
+    "pronominal_class": "hoq",
+    "notes": [],
+    "examples": [],
+    "fields": []
   },
   {
     "toaq": "zozeo",


### PR DESCRIPTION
**sey** seems to be a word form added semi-accidentally, and there are a bunch of existing **zıu** compounds in Toadua already, so I think it'd be nice to move it over