### PR TITLE
Mark verb classes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -203,6 +203,7 @@
     "frame": "",
     "distribution": "d d",
     "pronominal_class": "hoq",
+    "verb_class": "modality",
     "notes": [],
     "examples": [],
     "fields": []
@@ -537,6 +538,7 @@
     "frame": "",
     "distribution": "d d",
     "pronominal_class": "hoq",
+    "verb_class": "modality",
     "notes": [],
     "examples": [],
     "fields": []
@@ -671,6 +673,7 @@
     "frame": "",
     "distribution": "d; d d",
     "pronominal_class": "ta",
+    "verb_class": "neg",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1791,6 +1794,7 @@
     "frame": "",
     "distribution": "d; d d",
     "pronominal_class": "hoq",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3175,6 +3179,7 @@
     "frame": "",
     "distribution": "d d",
     "pronominal_class": "hoq",
+    "verb_class": "modality",
     "notes": [],
     "examples": [
       {
@@ -5720,6 +5725,7 @@
     "frame": "",
     "distribution": "d; d d",
     "pronominal_class": "ta",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6414,6 +6420,7 @@
     "frame": "",
     "distribution": "d; d d",
     "pronominal_class": "ta",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6453,6 +6460,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7189,6 +7197,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7217,6 +7226,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7231,6 +7241,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7910,6 +7921,7 @@
     "frame": "c 1",
     "distribution": "d; d d",
     "pronominal_class": "ta",
+    "verb_class": "neg",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9566,6 +9578,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11703,6 +11716,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13020,6 +13034,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13048,6 +13063,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13062,6 +13078,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "tense",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15921,6 +15938,7 @@
     "frame": "",
     "distribution": "d d",
     "pronominal_class": "hoq",
+    "verb_class": "modality",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18110,6 +18128,7 @@
     "frame": "",
     "distribution": "d",
     "pronominal_class": "hoq",
+    "verb_class": "aspect",
     "notes": [],
     "examples": [],
     "fields": []

--- a/dictionary.json
+++ b/dictionary.json
@@ -673,7 +673,7 @@
     "frame": "",
     "distribution": "d; d d",
     "pronominal_class": "ta",
-    "verb_class": "neg",
+    "verb_class": "negation",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7921,7 +7921,7 @@
     "frame": "c 1",
     "distribution": "d; d d",
     "pronominal_class": "ta",
-    "verb_class": "neg",
+    "verb_class": "negation",
     "notes": [],
     "examples": [],
     "fields": []

--- a/tools/normalize.js
+++ b/tools/normalize.js
@@ -73,7 +73,7 @@ d = d.map((obj) => {
 
   if (verbyTypes.includes(type)) {
     ensureField(["frame", "distribution", "pronominal_class"], "");
-    ensureField(["namesake"]);
+    ensureField(["verb_class", "namesake"]);
     ensureField(["notes", "examples"], []);
     ensureField(["fields"], []);
   } else {


### PR DESCRIPTION
Notes:

* I spelled them out in full because I've seen T vs. Tense, Asp vs. Aspect, Mod vs. Modality used interchangeably, but `T` is kinda like "what does T mean" whereas `tense` does not elicit such questions. Also "Mod" seems to get confused with "Mood" which it is not.
* I spelled them in lowercase just because the rest of the fields are all lowercase too, so it seemed less surprising.

It's trivial for a tool like zugai to consume `"tense"` and turn it into T in its output.