### PR TITLE
Replace invalid Gamma words

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -4606,6 +4606,16 @@
     "fields": []
   },
   {
+    "toaq": "fo",
+    "type": "sentence connector",
+    "english": "go on tangent",
+    "gloss": "by.the.way",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "foa",
     "type": "predicate",
     "english": "▯ feels ▯ (good or bad); ▯ is ▯ (ill or well).",
@@ -4646,16 +4656,6 @@
     "notes": [],
     "examples": [],
     "fields": []
-  },
-  {
-    "toaq": "fo",
-    "type": "sentence connector",
-    "english": "go on tangent",
-    "gloss": "by.the.way",
-    "short": "",
-    "keywords": [],
-    "notes": [],
-    "examples": []
   },
   {
     "toaq": "foı",
@@ -7475,6 +7475,16 @@
     "examples": []
   },
   {
+    "toaq": "jıbı",
+    "type": "vocative",
+    "english": "self-vocative",
+    "gloss": "this.is",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "jıbo",
     "type": "predicate",
     "english": "▯ is mine.",
@@ -7774,16 +7784,6 @@
     "notes": [],
     "examples": [],
     "fields": []
-  },
-  {
-    "toaq": "jıbı",
-    "type": "vocative",
-    "english": "self-vocative",
-    "gloss": "this.is",
-    "short": "",
-    "keywords": [],
-    "notes": [],
-    "examples": []
   },
   {
     "toaq": "jo",
@@ -16018,6 +16018,20 @@
     "fields": []
   },
   {
+    "toaq": "shıao",
+    "type": "predicate",
+    "english": "▯ disappears / leaves perception.",
+    "gloss": "disappear",
+    "short": "",
+    "keywords": [],
+    "frame": "c",
+    "distribution": "d",
+    "pronominal_class": "ta",
+    "notes": [],
+    "examples": [],
+    "fields": []
+  },
+  {
     "toaq": "shıu",
     "type": "predicate",
     "english": "▯ is before / in the past of ▯.",
@@ -16125,20 +16139,6 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "notes": [],
-    "examples": [],
-    "fields": []
-  },
-  {
-    "toaq": "shıao",
-    "type": "predicate",
-    "english": "▯ disappears / leaves perception.",
-    "gloss": "disappear",
-    "short": "",
-    "keywords": [],
-    "frame": "c",
-    "distribution": "d",
-    "pronominal_class": "ta",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17839,6 +17839,20 @@
     "examples": []
   },
   {
+    "toaq": "torea",
+    "type": "predicate",
+    "english": "▯ is a knife.",
+    "gloss": "knife",
+    "short": "",
+    "keywords": [],
+    "frame": "c",
+    "distribution": "d",
+    "pronominal_class": "maq",
+    "notes": [],
+    "examples": [],
+    "fields": []
+  },
+  {
     "toaq": "toq",
     "type": "predicate",
     "english": "▯ is a board.",
@@ -17997,20 +18011,6 @@
     "frame": "",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "notes": [],
-    "examples": [],
-    "fields": []
-  },
-  {
-    "toaq": "torea",
-    "type": "predicate",
-    "english": "▯ is a knife.",
-    "gloss": "knife",
-    "short": "",
-    "keywords": [],
-    "frame": "c",
-    "distribution": "d",
-    "pronominal_class": "maq",
     "notes": [],
     "examples": [],
     "fields": []

--- a/dictionary.json
+++ b/dictionary.json
@@ -1044,7 +1044,7 @@
     "fields": []
   },
   {
-    "toaq": "buzy",
+    "toaq": "buza",
     "type": "interjection",
     "english": "expressing a lack of knowledge",
     "gloss": "dunno",
@@ -2753,7 +2753,7 @@
     "fields": []
   },
   {
-    "toaq": "choakoy",
+    "toaq": "choadeoq",
     "type": "predicate",
     "english": "▯ talks to ▯.",
     "gloss": "talk",
@@ -4648,7 +4648,7 @@
     "fields": []
   },
   {
-    "toaq": "fou",
+    "toaq": "fo",
     "type": "sentence connector",
     "english": "go on tangent",
     "gloss": "by.the.way",
@@ -7776,7 +7776,7 @@
     "fields": []
   },
   {
-    "toaq": "jıy",
+    "toaq": "jıbı",
     "type": "vocative",
     "english": "self-vocative",
     "gloss": "this.is",
@@ -15532,7 +15532,7 @@
     "fields": []
   },
   {
-    "toaq": "suy",
+    "toaq": "sueq",
     "type": "predicate",
     "english": "▯ is a wave.",
     "gloss": "wave",
@@ -16130,7 +16130,7 @@
     "fields": []
   },
   {
-    "toaq": "shıy",
+    "toaq": "shıao",
     "type": "predicate",
     "english": "▯ disappears / leaves perception.",
     "gloss": "disappear",
@@ -17321,7 +17321,7 @@
     "fields": []
   },
   {
-    "toaq": "tuımy",
+    "toaq": "tuıfua",
     "type": "predicate",
     "english": "▯ is a seat/chair/stool/bench.",
     "gloss": "seat",
@@ -18002,7 +18002,7 @@
     "fields": []
   },
   {
-    "toaq": "toemy",
+    "toaq": "torea",
     "type": "predicate",
     "english": "▯ is a knife.",
     "gloss": "knife",


### PR DESCRIPTION
Addresses #154 

- buzy -> buza: from toadua
- choakoy -> choadeoq: koy was replaced by deoq in Delta
- fou -> fo: #154
- jıy -> jıbı: #154; an alternative on toadua is jıhu, but hu is now hoı and jıhoı starts to feel a bit long?
- suy -> sueq: from toadua
- shıy -> shıao: from toadua; shıeq also suggested, but shıao seems more popular
- tuımy -> tuıfua: from toadua, also seems very sensible
- toemy -> torea: from toadua, shortening of toerea; toerea also seems like a good option