### PR TITLE
Annotate more subject types

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1179,7 +1179,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1544,7 +1544,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "free",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1619,7 +1619,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "subject": "proposition",
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1809,7 +1809,7 @@
     "frame": "c 2ix",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2009,7 +2009,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "subject": "shape",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3184,7 +3184,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3836,7 +3836,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3851,7 +3851,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4046,7 +4046,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4302,7 +4302,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -4386,7 +4386,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "free",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4622,7 +4622,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4779,7 +4779,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4964,7 +4964,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5001,7 +5001,7 @@
     "frame": "c ci 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [
       "The third place property is maintained for as long as the second place property is being satisfied."
     ],
@@ -5083,7 +5083,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5128,7 +5128,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5143,7 +5143,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5278,7 +5278,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5637,7 +5637,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6698,7 +6698,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6773,7 +6773,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6953,7 +6953,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [
       {
@@ -6973,7 +6973,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7328,7 +7328,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7463,7 +7463,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7713,7 +7713,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7883,7 +7883,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [
       {
@@ -8107,7 +8107,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8277,7 +8277,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8877,7 +8877,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9697,7 +9697,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12015,7 +12015,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12262,7 +12262,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ze",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13705,7 +13705,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13892,7 +13892,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14072,7 +14072,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14192,7 +14192,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14237,7 +14237,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14312,7 +14312,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14327,7 +14327,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14372,7 +14372,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14387,7 +14387,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14402,7 +14402,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14902,7 +14902,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15204,7 +15204,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15659,7 +15659,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15674,7 +15674,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15779,7 +15779,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16057,7 +16057,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16897,7 +16897,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17257,7 +17257,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "subject": "individual",
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17596,7 +17596,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17881,7 +17881,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18101,7 +18101,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18660,7 +18660,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18675,7 +18675,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18690,7 +18690,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18876,7 +18876,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19224,7 +19224,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "subject": "individual",
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []

--- a/dictionary.json
+++ b/dictionary.json
@@ -39,7 +39,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -84,7 +84,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -99,7 +99,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -114,7 +114,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -129,7 +129,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -144,7 +144,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -159,7 +159,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -174,7 +174,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -199,7 +199,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -214,7 +214,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -229,7 +229,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -244,7 +244,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -279,7 +279,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -294,7 +294,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -339,7 +339,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -364,7 +364,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -399,7 +399,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -414,7 +414,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -439,7 +439,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -484,7 +484,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -519,7 +519,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -534,7 +534,7 @@
     "frame": "c 1i",
     "distribution": "n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -549,7 +549,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -564,7 +564,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -579,7 +579,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -594,7 +594,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -609,7 +609,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -634,7 +634,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -649,7 +649,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -664,7 +664,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -699,7 +699,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -724,7 +724,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -779,7 +779,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -794,7 +794,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -849,7 +849,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -864,7 +864,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -879,7 +879,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -904,7 +904,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -929,7 +929,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -969,7 +969,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -984,7 +984,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -999,7 +999,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1034,7 +1034,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1049,7 +1049,7 @@
     "frame": "c e",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1064,7 +1064,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1082,7 +1082,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [
       "▯ asserts that ▯ is not the case."
     ],
@@ -1119,7 +1119,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1134,7 +1134,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1149,7 +1149,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1164,7 +1164,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1179,7 +1179,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1194,7 +1194,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1209,7 +1209,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1224,7 +1224,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1239,7 +1239,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1254,7 +1254,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1269,7 +1269,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1284,7 +1284,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1309,7 +1309,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1324,7 +1324,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1339,7 +1339,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1354,7 +1354,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1369,7 +1369,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1384,7 +1384,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1399,7 +1399,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1414,7 +1414,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1429,7 +1429,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1444,7 +1444,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1459,7 +1459,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1474,7 +1474,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1489,7 +1489,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1504,7 +1504,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1544,7 +1544,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1559,7 +1559,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1574,7 +1574,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1589,7 +1589,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1604,7 +1604,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1619,7 +1619,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1634,7 +1634,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1649,7 +1649,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1664,7 +1664,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1679,7 +1679,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1714,7 +1714,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1729,7 +1729,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1744,7 +1744,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1759,7 +1759,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1774,7 +1774,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1809,7 +1809,7 @@
     "frame": "c 2ix",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1824,7 +1824,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1839,7 +1839,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1854,7 +1854,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1869,7 +1869,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1884,7 +1884,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1899,7 +1899,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1914,7 +1914,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1929,7 +1929,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1944,7 +1944,7 @@
     "frame": "c ci 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1959,7 +1959,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -1974,7 +1974,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -1994,7 +1994,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2009,7 +2009,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2024,7 +2024,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2039,7 +2039,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2054,7 +2054,7 @@
     "frame": "c c 2ij",
     "distribution": "n n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2069,7 +2069,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2084,7 +2084,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2109,7 +2109,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2124,7 +2124,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2139,7 +2139,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2154,7 +2154,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2169,7 +2169,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2184,7 +2184,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2199,7 +2199,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2224,7 +2224,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2239,7 +2239,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2254,7 +2254,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2269,7 +2269,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2284,7 +2284,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2299,7 +2299,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2314,7 +2314,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2329,7 +2329,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2344,7 +2344,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2359,7 +2359,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2374,7 +2374,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -2394,7 +2394,7 @@
     "frame": "",
     "distribution": "",
     "pronominal_class": "",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -2414,7 +2414,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2429,7 +2429,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2444,7 +2444,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2459,7 +2459,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2474,7 +2474,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2489,7 +2489,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2504,7 +2504,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2519,7 +2519,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2534,7 +2534,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2549,7 +2549,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2564,7 +2564,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2589,7 +2589,7 @@
     "frame": "c 1i 1i",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2604,7 +2604,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2619,7 +2619,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2634,7 +2634,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2649,7 +2649,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2664,7 +2664,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2679,7 +2679,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2694,7 +2694,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2709,7 +2709,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2724,7 +2724,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2739,7 +2739,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2759,7 +2759,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -2798,7 +2798,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2813,7 +2813,7 @@
     "frame": "c c c",
     "distribution": "d d n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2828,7 +2828,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2843,7 +2843,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "ta_strong",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2858,7 +2858,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "ta_strong",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2873,7 +2873,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2888,7 +2888,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2903,7 +2903,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2918,7 +2918,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2933,7 +2933,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2948,7 +2948,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2963,7 +2963,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2978,7 +2978,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -2993,7 +2993,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3008,7 +3008,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3023,7 +3023,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3038,7 +3038,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3053,7 +3053,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3078,7 +3078,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3093,7 +3093,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3108,7 +3108,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3123,7 +3123,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3138,7 +3138,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3153,7 +3153,7 @@
     "frame": "c 2xx",
     "distribution": "n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -3169,7 +3169,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3184,7 +3184,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3199,7 +3199,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3214,7 +3214,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3229,7 +3229,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3244,7 +3244,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3259,7 +3259,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3274,7 +3274,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3289,7 +3289,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3304,7 +3304,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3319,7 +3319,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3334,7 +3334,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3349,7 +3349,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3364,7 +3364,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3379,7 +3379,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3394,7 +3394,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3409,7 +3409,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3445,7 +3445,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3460,7 +3460,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3475,7 +3475,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3490,7 +3490,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3505,7 +3505,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3520,7 +3520,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3535,7 +3535,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3550,7 +3550,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3565,7 +3565,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3580,7 +3580,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3595,7 +3595,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3610,7 +3610,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3635,7 +3635,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3650,7 +3650,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3665,7 +3665,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3680,7 +3680,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3695,7 +3695,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3710,7 +3710,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3725,7 +3725,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3740,7 +3740,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3755,7 +3755,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3770,7 +3770,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [
       {
@@ -3790,7 +3790,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3805,7 +3805,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3820,7 +3820,7 @@
     "frame": "c c 0",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -3836,7 +3836,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3851,7 +3851,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3866,7 +3866,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3881,7 +3881,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3896,7 +3896,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3911,7 +3911,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3926,7 +3926,7 @@
     "frame": "c 1i 1i",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3941,7 +3941,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3956,7 +3956,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3971,7 +3971,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -3986,7 +3986,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4001,7 +4001,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4009,14 +4009,14 @@
   {
     "toaq": "dıaq",
     "type": "predicate",
-    "english": "▯ occurs at regular intervals; ▯ satisfies property ▯ at regular intervals.",
+    "english": "▯ occurs at regular intervals.",
     "gloss": "regular",
     "short": "",
     "keywords": [],
-    "frame": "c 1i",
+    "frame": "0",
     "distribution": "d",
-    "pronominal_class": "ta",
-    "agent_subject": false,
+    "pronominal_class": "hoq",
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4031,7 +4031,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4046,7 +4046,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4061,7 +4061,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4076,7 +4076,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4091,7 +4091,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4106,7 +4106,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4121,7 +4121,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4136,7 +4136,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4151,7 +4151,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4166,7 +4166,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4181,7 +4181,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4196,7 +4196,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4211,7 +4211,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4226,7 +4226,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4241,7 +4241,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4266,7 +4266,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4281,7 +4281,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4302,7 +4302,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [
       {
@@ -4341,7 +4341,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4356,7 +4356,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4371,7 +4371,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4386,7 +4386,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4401,7 +4401,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4416,7 +4416,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4431,7 +4431,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4450,7 +4450,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -4477,7 +4477,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4492,7 +4492,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4517,7 +4517,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4532,7 +4532,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4547,7 +4547,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4562,7 +4562,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4577,7 +4577,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4592,7 +4592,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4607,7 +4607,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4622,7 +4622,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4637,7 +4637,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4652,7 +4652,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4667,7 +4667,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4682,7 +4682,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4697,7 +4697,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4712,7 +4712,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4727,7 +4727,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [
       "Can refer to any body or group of people tasked with carrying out a particular function or with the accomplishment of some specific purpose."
     ],
@@ -4744,7 +4744,7 @@
     "frame": "c 2xi",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -4764,7 +4764,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4779,7 +4779,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4804,7 +4804,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4819,7 +4819,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4834,7 +4834,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4849,7 +4849,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4864,7 +4864,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4879,7 +4879,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4904,7 +4904,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4919,7 +4919,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4934,7 +4934,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4949,7 +4949,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4964,7 +4964,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -4979,7 +4979,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5001,7 +5001,7 @@
     "frame": "c ci 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [
       "The third place property is maintained for as long as the second place property is being satisfied."
     ],
@@ -5023,7 +5023,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5038,7 +5038,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5053,7 +5053,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5068,7 +5068,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5083,7 +5083,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5098,7 +5098,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5113,7 +5113,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5128,7 +5128,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5143,7 +5143,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5158,7 +5158,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5173,7 +5173,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5188,7 +5188,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5203,7 +5203,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5215,10 +5215,10 @@
     "gloss": "twice",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5233,7 +5233,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5248,7 +5248,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5263,7 +5263,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5278,7 +5278,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5293,7 +5293,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5308,7 +5308,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5323,7 +5323,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5338,7 +5338,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5353,7 +5353,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5368,7 +5368,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5383,7 +5383,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5398,7 +5398,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5413,7 +5413,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5428,7 +5428,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5443,7 +5443,7 @@
     "frame": "c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5458,7 +5458,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5473,7 +5473,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5488,7 +5488,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5503,7 +5503,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5515,10 +5515,10 @@
     "gloss": "sometimes",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5530,10 +5530,10 @@
     "gloss": "never",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5548,7 +5548,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5563,7 +5563,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5578,7 +5578,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "namesake": true,
     "notes": [],
     "examples": [
@@ -5607,7 +5607,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5622,7 +5622,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5637,7 +5637,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5652,7 +5652,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5667,7 +5667,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5682,7 +5682,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5697,7 +5697,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5712,7 +5712,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5727,7 +5727,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5742,7 +5742,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5757,7 +5757,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5772,7 +5772,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5787,7 +5787,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5802,7 +5802,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5817,7 +5817,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5832,7 +5832,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5847,7 +5847,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5862,7 +5862,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5877,7 +5877,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5892,7 +5892,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5907,7 +5907,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5922,7 +5922,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5937,7 +5937,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5952,7 +5952,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5977,7 +5977,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -5992,7 +5992,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6007,7 +6007,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6022,7 +6022,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6037,7 +6037,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6052,7 +6052,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "hoq",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6067,7 +6067,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6082,7 +6082,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6097,7 +6097,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6112,7 +6112,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6137,7 +6137,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6152,7 +6152,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6167,7 +6167,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6182,7 +6182,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6197,7 +6197,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6212,7 +6212,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6227,7 +6227,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6242,7 +6242,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6257,7 +6257,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6272,7 +6272,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6287,7 +6287,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6322,7 +6322,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6337,7 +6337,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6352,7 +6352,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6367,7 +6367,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6382,7 +6382,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6397,7 +6397,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6412,7 +6412,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6437,7 +6437,7 @@
     "frame": "vcriable",
     "distribution": "variable",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6462,7 +6462,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6477,7 +6477,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6502,7 +6502,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6517,7 +6517,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6532,7 +6532,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -6548,7 +6548,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6563,7 +6563,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6578,7 +6578,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6593,7 +6593,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6608,7 +6608,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6623,7 +6623,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6638,7 +6638,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6653,7 +6653,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6668,7 +6668,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6683,7 +6683,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6698,7 +6698,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6713,7 +6713,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6728,7 +6728,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6743,7 +6743,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6758,7 +6758,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6773,7 +6773,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6788,7 +6788,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6803,7 +6803,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6848,7 +6848,7 @@
     "frame": "c 2ix",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6863,7 +6863,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6878,7 +6878,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6893,7 +6893,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6908,7 +6908,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6923,7 +6923,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6938,7 +6938,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6953,7 +6953,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -6973,7 +6973,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -6988,7 +6988,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7003,7 +7003,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7028,7 +7028,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7043,7 +7043,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7068,7 +7068,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [
       {
@@ -7088,7 +7088,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7100,10 +7100,10 @@
     "gloss": "therefore",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [
       {
@@ -7133,7 +7133,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7148,7 +7148,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7183,7 +7183,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7208,7 +7208,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7223,7 +7223,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7238,7 +7238,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7253,7 +7253,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7268,7 +7268,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7283,7 +7283,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7298,7 +7298,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7313,7 +7313,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7328,7 +7328,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7343,7 +7343,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7358,7 +7358,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7373,7 +7373,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7388,7 +7388,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7403,7 +7403,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7448,7 +7448,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7463,7 +7463,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7478,7 +7478,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7493,7 +7493,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7508,7 +7508,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7523,7 +7523,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7538,7 +7538,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7553,7 +7553,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7568,7 +7568,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7583,7 +7583,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7598,7 +7598,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7613,7 +7613,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7628,7 +7628,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7643,7 +7643,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7658,7 +7658,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7683,7 +7683,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7698,7 +7698,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7713,7 +7713,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7728,7 +7728,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7743,7 +7743,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7778,7 +7778,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7793,7 +7793,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7808,7 +7808,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7823,7 +7823,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7838,7 +7838,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7853,7 +7853,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7868,7 +7868,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7883,7 +7883,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -7907,7 +7907,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7922,7 +7922,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7957,7 +7957,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7972,7 +7972,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -7987,7 +7987,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8012,7 +8012,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8047,7 +8047,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8062,7 +8062,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8077,7 +8077,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8092,7 +8092,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8107,7 +8107,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8122,7 +8122,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8137,7 +8137,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8152,7 +8152,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8167,7 +8167,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8182,7 +8182,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8197,7 +8197,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8212,7 +8212,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8227,7 +8227,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8242,7 +8242,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [
       {
@@ -8262,7 +8262,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8277,7 +8277,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8292,7 +8292,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8307,7 +8307,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8322,7 +8322,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8337,7 +8337,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8352,7 +8352,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8367,7 +8367,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8382,7 +8382,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8397,7 +8397,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8412,7 +8412,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8427,7 +8427,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8442,7 +8442,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8457,7 +8457,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8472,7 +8472,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [
       {
@@ -8496,7 +8496,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8511,7 +8511,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8526,7 +8526,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8571,7 +8571,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8586,7 +8586,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -8602,7 +8602,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8617,7 +8617,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8632,7 +8632,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8647,7 +8647,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8662,7 +8662,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8677,7 +8677,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8692,7 +8692,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8707,7 +8707,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8722,7 +8722,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ze",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8747,7 +8747,7 @@
     "frame": "c c 0",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8762,7 +8762,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8787,7 +8787,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8802,7 +8802,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8817,7 +8817,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8832,7 +8832,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8847,7 +8847,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8862,7 +8862,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8877,7 +8877,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8892,7 +8892,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8907,7 +8907,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8922,7 +8922,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8937,7 +8937,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8952,7 +8952,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8967,7 +8967,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8982,7 +8982,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -8997,7 +8997,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9012,7 +9012,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9027,7 +9027,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9042,7 +9042,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9057,7 +9057,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9072,7 +9072,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9097,7 +9097,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9132,7 +9132,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9147,7 +9147,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9172,7 +9172,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9187,7 +9187,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9202,7 +9202,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9217,7 +9217,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9232,7 +9232,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9247,7 +9247,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9262,7 +9262,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9277,7 +9277,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9292,7 +9292,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9307,7 +9307,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9322,7 +9322,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [
       {
@@ -9342,7 +9342,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9357,7 +9357,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9372,7 +9372,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9387,7 +9387,7 @@
     "frame": "c c 1x",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9402,7 +9402,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9417,7 +9417,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9432,7 +9432,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9447,7 +9447,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9462,7 +9462,7 @@
     "frame": "c c",
     "distribution": "n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9477,7 +9477,7 @@
     "frame": "c c c",
     "distribution": "d n d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9522,7 +9522,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9537,7 +9537,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9552,7 +9552,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9567,7 +9567,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9582,7 +9582,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9597,7 +9597,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9612,7 +9612,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9627,7 +9627,7 @@
     "frame": "c 2xi",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9652,7 +9652,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9667,7 +9667,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9682,7 +9682,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9697,7 +9697,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9712,7 +9712,7 @@
     "frame": "c c 1x 1x",
     "distribution": "d n d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9727,7 +9727,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9742,7 +9742,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9757,7 +9757,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9772,7 +9772,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9787,7 +9787,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9802,7 +9802,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9817,7 +9817,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9832,7 +9832,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9847,7 +9847,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9862,7 +9862,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9877,7 +9877,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9892,7 +9892,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9907,7 +9907,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9922,7 +9922,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9937,7 +9937,7 @@
     "frame": "c c c 2ij",
     "distribution": "d d n d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9952,7 +9952,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9977,7 +9977,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -9992,7 +9992,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10007,7 +10007,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10022,7 +10022,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10037,7 +10037,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10056,7 +10056,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -10091,7 +10091,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10126,7 +10126,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10141,7 +10141,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10156,7 +10156,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10171,7 +10171,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10186,7 +10186,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10201,7 +10201,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10216,7 +10216,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10231,7 +10231,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10246,7 +10246,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10261,7 +10261,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10276,7 +10276,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10291,7 +10291,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10306,7 +10306,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10321,7 +10321,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10336,7 +10336,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10351,7 +10351,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [
       "A projecting rim of an open container or of a part of the body."
     ],
@@ -10378,7 +10378,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10393,7 +10393,7 @@
     "frame": "c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10408,7 +10408,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10423,7 +10423,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10438,7 +10438,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10453,7 +10453,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10468,7 +10468,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10483,7 +10483,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10498,7 +10498,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10513,7 +10513,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10528,7 +10528,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10543,7 +10543,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10558,7 +10558,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10573,7 +10573,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10588,7 +10588,7 @@
     "frame": "c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10603,7 +10603,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10618,7 +10618,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10633,7 +10633,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10648,7 +10648,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10663,7 +10663,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10678,7 +10678,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10693,7 +10693,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10708,7 +10708,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10723,7 +10723,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10738,7 +10738,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10763,7 +10763,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10778,7 +10778,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10793,7 +10793,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10808,7 +10808,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10823,7 +10823,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10838,7 +10838,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10853,7 +10853,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10868,7 +10868,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10883,7 +10883,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10898,7 +10898,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10913,7 +10913,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10928,7 +10928,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10943,7 +10943,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10958,7 +10958,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10973,7 +10973,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -10988,7 +10988,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11003,7 +11003,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11018,7 +11018,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11033,7 +11033,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11048,7 +11048,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11063,7 +11063,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -11079,7 +11079,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11094,7 +11094,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11139,7 +11139,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11154,7 +11154,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11169,7 +11169,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11184,7 +11184,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11209,7 +11209,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11224,7 +11224,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11239,7 +11239,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11254,7 +11254,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11279,7 +11279,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11314,7 +11314,7 @@
     "frame": "c c 2ji",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -11334,7 +11334,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11349,7 +11349,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11364,7 +11364,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11379,7 +11379,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11394,7 +11394,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11409,7 +11409,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11424,7 +11424,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11439,7 +11439,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11454,7 +11454,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11469,7 +11469,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11484,7 +11484,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11499,7 +11499,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11514,7 +11514,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11529,7 +11529,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11544,7 +11544,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11559,7 +11559,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11574,7 +11574,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11589,7 +11589,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11604,7 +11604,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -11620,7 +11620,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11635,7 +11635,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11650,7 +11650,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11665,7 +11665,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11680,7 +11680,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11695,7 +11695,7 @@
     "frame": "c 2ix",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11710,7 +11710,7 @@
     "frame": "c 2ix",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11725,7 +11725,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11740,7 +11740,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11755,7 +11755,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11770,7 +11770,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11785,7 +11785,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11800,7 +11800,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11815,7 +11815,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11830,7 +11830,7 @@
     "frame": "c c 0",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11845,7 +11845,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11860,7 +11860,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11875,7 +11875,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11890,7 +11890,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11905,7 +11905,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11920,7 +11920,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11935,7 +11935,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11970,7 +11970,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -11985,7 +11985,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12000,7 +12000,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12015,7 +12015,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12030,7 +12030,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12045,7 +12045,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12060,7 +12060,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12075,7 +12075,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12090,7 +12090,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12105,7 +12105,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12120,7 +12120,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12135,7 +12135,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12150,7 +12150,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12168,7 +12168,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [
       "The emotion is expressed as a property."
     ],
@@ -12187,7 +12187,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12202,7 +12202,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12217,7 +12217,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12232,7 +12232,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12247,7 +12247,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12262,7 +12262,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ze",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12277,7 +12277,7 @@
     "frame": "c c",
     "distribution": "n n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [
       "Equivalent to binary heo."
     ],
@@ -12294,7 +12294,7 @@
     "frame": "c c",
     "distribution": "n n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [
       "Same as binary jeq."
     ],
@@ -12311,7 +12311,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12326,7 +12326,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12341,7 +12341,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12356,7 +12356,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12371,7 +12371,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12386,7 +12386,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12401,7 +12401,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12416,7 +12416,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12431,7 +12431,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12456,7 +12456,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12471,7 +12471,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12486,7 +12486,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12501,7 +12501,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12526,7 +12526,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12541,7 +12541,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12556,7 +12556,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12571,7 +12571,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12586,7 +12586,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12601,7 +12601,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12616,7 +12616,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12631,7 +12631,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12656,7 +12656,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12671,7 +12671,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12686,7 +12686,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12701,7 +12701,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12716,7 +12716,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12731,7 +12731,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12746,7 +12746,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -12766,7 +12766,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12781,7 +12781,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12796,7 +12796,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12811,7 +12811,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12826,7 +12826,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12841,7 +12841,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12856,7 +12856,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12871,7 +12871,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12886,7 +12886,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12901,7 +12901,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12916,7 +12916,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12931,7 +12931,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12946,7 +12946,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12961,7 +12961,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12976,7 +12976,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -12991,7 +12991,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13006,7 +13006,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13021,7 +13021,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13036,7 +13036,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13051,7 +13051,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13066,7 +13066,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13081,7 +13081,7 @@
     "frame": "c c 1i",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13096,7 +13096,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13141,7 +13141,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13156,7 +13156,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13181,7 +13181,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13206,7 +13206,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13241,7 +13241,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13266,7 +13266,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13281,7 +13281,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13316,7 +13316,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13331,7 +13331,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13346,7 +13346,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13361,7 +13361,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13376,7 +13376,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13391,7 +13391,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13406,7 +13406,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13421,7 +13421,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13436,7 +13436,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13451,7 +13451,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13466,7 +13466,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13481,7 +13481,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13496,7 +13496,7 @@
     "frame": "",
     "distribution": "",
     "pronominal_class": "",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -13516,7 +13516,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13531,7 +13531,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13546,7 +13546,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13561,7 +13561,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13576,7 +13576,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13591,7 +13591,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13606,7 +13606,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13621,7 +13621,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13636,7 +13636,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13651,7 +13651,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13666,7 +13666,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -13690,7 +13690,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13705,7 +13705,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13720,7 +13720,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13735,7 +13735,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13750,7 +13750,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13765,7 +13765,7 @@
     "frame": "c 2xi",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -13785,7 +13785,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13800,7 +13800,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13815,7 +13815,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13830,7 +13830,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13845,7 +13845,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13860,7 +13860,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [
       "This word does not imply good luck by itself. See **gıneq** and **huıneq** for good and bad luck respectively."
     ],
@@ -13877,7 +13877,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13892,7 +13892,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13907,7 +13907,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13922,7 +13922,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13937,7 +13937,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13952,7 +13952,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13967,7 +13967,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13982,7 +13982,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -13997,7 +13997,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14012,7 +14012,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14027,7 +14027,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14042,7 +14042,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14057,7 +14057,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14072,7 +14072,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14087,7 +14087,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14102,7 +14102,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14117,7 +14117,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14132,7 +14132,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14157,7 +14157,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14192,7 +14192,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14207,7 +14207,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14222,7 +14222,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14237,7 +14237,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14252,7 +14252,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14267,7 +14267,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14282,7 +14282,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14297,7 +14297,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14312,7 +14312,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14327,7 +14327,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14342,7 +14342,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14357,7 +14357,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14372,7 +14372,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14387,7 +14387,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14402,7 +14402,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14417,7 +14417,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14432,7 +14432,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14447,7 +14447,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14462,7 +14462,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14477,7 +14477,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14492,7 +14492,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14507,7 +14507,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14522,7 +14522,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14537,7 +14537,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14552,7 +14552,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14567,7 +14567,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14582,7 +14582,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14597,7 +14597,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14612,7 +14612,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14627,7 +14627,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14642,7 +14642,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14657,7 +14657,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14672,7 +14672,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14687,7 +14687,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14702,7 +14702,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14717,7 +14717,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14732,7 +14732,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14747,7 +14747,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ze",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14762,7 +14762,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14777,7 +14777,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14792,7 +14792,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14807,7 +14807,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14822,7 +14822,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14837,7 +14837,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14852,7 +14852,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14867,7 +14867,7 @@
     "frame": "c c 2xx",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14882,7 +14882,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [
       {
@@ -14902,7 +14902,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14917,7 +14917,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14932,7 +14932,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14947,7 +14947,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [
       {
@@ -14967,7 +14967,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -14992,7 +14992,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15007,7 +15007,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15022,7 +15022,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15037,7 +15037,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "raı",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15052,7 +15052,7 @@
     "frame": "c c",
     "distribution": "n n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15067,7 +15067,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15082,7 +15082,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [
       {
@@ -15124,7 +15124,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15139,7 +15139,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15154,7 +15154,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15169,7 +15169,7 @@
     "frame": "",
     "distribution": "",
     "pronominal_class": "",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -15189,7 +15189,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15204,7 +15204,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15219,7 +15219,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15234,7 +15234,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15249,7 +15249,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15264,7 +15264,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15279,7 +15279,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15294,7 +15294,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15319,7 +15319,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15334,7 +15334,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15349,7 +15349,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15364,7 +15364,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15379,7 +15379,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15394,7 +15394,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15409,7 +15409,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15434,7 +15434,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15449,7 +15449,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15464,7 +15464,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15479,7 +15479,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15494,7 +15494,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15509,7 +15509,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15524,7 +15524,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15539,7 +15539,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15554,7 +15554,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15569,7 +15569,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15584,7 +15584,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15599,7 +15599,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15614,7 +15614,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15629,7 +15629,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15644,7 +15644,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15659,7 +15659,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15674,7 +15674,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15699,7 +15699,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15714,7 +15714,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15729,7 +15729,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -15749,7 +15749,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15764,7 +15764,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15779,7 +15779,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15794,7 +15794,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15819,7 +15819,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15834,7 +15834,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15849,7 +15849,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15864,7 +15864,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15879,7 +15879,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15894,7 +15894,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15909,7 +15909,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -15933,7 +15933,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15948,7 +15948,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15963,7 +15963,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -15978,7 +15978,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16012,7 +16012,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16027,7 +16027,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16042,7 +16042,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16057,7 +16057,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16069,10 +16069,10 @@
     "gloss": "thrice",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16087,7 +16087,7 @@
     "frame": "c c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16102,7 +16102,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16117,7 +16117,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16132,7 +16132,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16147,7 +16147,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16162,7 +16162,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16177,7 +16177,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16192,7 +16192,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16207,7 +16207,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16222,7 +16222,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16257,7 +16257,7 @@
     "frame": "vcriable",
     "distribution": "n",
     "pronominal_class": "",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16272,7 +16272,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16297,7 +16297,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16322,7 +16322,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16337,7 +16337,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16362,7 +16362,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16377,7 +16377,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16392,7 +16392,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16407,7 +16407,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16422,7 +16422,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16437,7 +16437,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16452,7 +16452,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16467,7 +16467,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16482,7 +16482,7 @@
     "frame": "c c 1x",
     "distribution": "d n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16497,7 +16497,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16512,7 +16512,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16527,7 +16527,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16542,7 +16542,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16567,7 +16567,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16582,7 +16582,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16597,7 +16597,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16612,7 +16612,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16627,7 +16627,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16642,7 +16642,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16657,7 +16657,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16672,7 +16672,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16687,7 +16687,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16702,7 +16702,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16717,7 +16717,7 @@
     "frame": "c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16732,7 +16732,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16747,7 +16747,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16762,7 +16762,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16777,7 +16777,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16792,7 +16792,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16807,7 +16807,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16822,7 +16822,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16837,7 +16837,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16852,7 +16852,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16867,7 +16867,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16882,7 +16882,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16897,7 +16897,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16909,10 +16909,10 @@
     "gloss": "once",
     "short": "",
     "keywords": [],
-    "frame": "c",
+    "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16927,7 +16927,7 @@
     "frame": "c c",
     "distribution": "d n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16942,7 +16942,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16957,7 +16957,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16972,7 +16972,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -16987,7 +16987,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17002,7 +17002,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17017,7 +17017,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17032,7 +17032,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17047,7 +17047,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17062,7 +17062,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17077,7 +17077,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "event",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17092,7 +17092,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17107,7 +17107,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17122,7 +17122,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17137,7 +17137,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17152,7 +17152,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17167,7 +17167,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17182,7 +17182,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17197,7 +17197,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17212,7 +17212,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17227,7 +17227,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17242,7 +17242,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17257,7 +17257,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17272,7 +17272,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17307,7 +17307,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17322,7 +17322,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17337,7 +17337,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17352,7 +17352,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17367,7 +17367,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17382,7 +17382,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17397,7 +17397,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17412,7 +17412,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17427,7 +17427,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17442,7 +17442,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17457,7 +17457,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17472,7 +17472,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17487,7 +17487,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17521,7 +17521,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17536,7 +17536,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17551,7 +17551,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17566,7 +17566,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17581,7 +17581,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17596,7 +17596,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17611,7 +17611,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17626,7 +17626,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17641,7 +17641,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17656,7 +17656,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17671,7 +17671,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17686,7 +17686,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17701,7 +17701,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17716,7 +17716,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17731,7 +17731,7 @@
     "frame": "c c 1x",
     "distribution": "d n d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17746,7 +17746,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17761,7 +17761,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17776,7 +17776,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17791,7 +17791,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17806,7 +17806,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17821,7 +17821,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17836,7 +17836,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17851,7 +17851,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ta_strong",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17866,7 +17866,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17881,7 +17881,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17896,7 +17896,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17911,7 +17911,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17926,7 +17926,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17941,7 +17941,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17956,7 +17956,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17971,7 +17971,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -17986,7 +17986,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [
       {
@@ -18006,7 +18006,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18041,7 +18041,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18056,7 +18056,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18071,7 +18071,7 @@
     "frame": "c 2ii",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18086,7 +18086,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18101,7 +18101,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18116,7 +18116,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18131,7 +18131,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18146,7 +18146,7 @@
     "frame": "c c 1j",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18161,7 +18161,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18176,7 +18176,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18191,7 +18191,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18206,7 +18206,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18221,7 +18221,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18236,7 +18236,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18299,7 +18299,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18314,7 +18314,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18329,7 +18329,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18344,7 +18344,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "namesake": true,
     "notes": [],
     "examples": [],
@@ -18360,7 +18360,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18375,7 +18375,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18390,7 +18390,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18405,7 +18405,7 @@
     "frame": "0",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "proposition",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18420,7 +18420,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18435,7 +18435,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18450,7 +18450,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18465,7 +18465,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18480,7 +18480,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18495,7 +18495,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18510,7 +18510,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18525,7 +18525,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18540,7 +18540,7 @@
     "frame": "c 1x",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18555,7 +18555,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18570,7 +18570,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18585,7 +18585,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18600,7 +18600,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18615,7 +18615,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18630,7 +18630,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18645,7 +18645,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18660,7 +18660,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18675,7 +18675,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18690,7 +18690,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18705,7 +18705,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18720,7 +18720,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18735,7 +18735,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18750,7 +18750,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18769,7 +18769,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [
       "Refers to any member of the taxonomic order Lepidoptera."
     ],
@@ -18786,7 +18786,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "shape",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18801,7 +18801,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18816,7 +18816,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18831,7 +18831,7 @@
     "frame": "c c 2ij",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18876,7 +18876,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18891,7 +18891,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18906,7 +18906,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18921,7 +18921,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18936,7 +18936,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18951,7 +18951,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -18966,7 +18966,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19001,7 +19001,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19016,7 +19016,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19031,7 +19031,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19046,7 +19046,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19061,7 +19061,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19076,7 +19076,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19091,7 +19091,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19106,7 +19106,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19121,7 +19121,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19140,7 +19140,7 @@
     "frame": "c c 2ij",
     "distribution": "d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [
       "This word expresses the generic agent-patient relationship."
     ],
@@ -19174,7 +19174,7 @@
     "frame": "c c c",
     "distribution": "d d d",
     "pronominal_class": "ta",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19204,7 +19204,7 @@
     "frame": "c 2xi",
     "distribution": "d d",
     "pronominal_class": "ta_strong",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [
       {
@@ -19224,7 +19224,7 @@
     "frame": "c",
     "distribution": "n",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19239,7 +19239,7 @@
     "frame": "c c c 1k",
     "distribution": "d d d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19254,7 +19254,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19269,7 +19269,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19284,7 +19284,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19299,7 +19299,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19314,7 +19314,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19329,7 +19329,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19344,7 +19344,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19369,7 +19369,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [
       "Refers to a quote rather than a fifth tone content clause."
     ],
@@ -19386,7 +19386,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": true,
+    "subject": "agent",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19411,7 +19411,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19426,7 +19426,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19441,7 +19441,7 @@
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19456,7 +19456,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19471,7 +19471,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19486,7 +19486,7 @@
     "frame": "c 1i",
     "distribution": "d d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "free",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19501,7 +19501,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "ta",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19536,7 +19536,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19551,7 +19551,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "hoq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19566,7 +19566,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19581,7 +19581,7 @@
     "frame": "c 0",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []
@@ -19596,7 +19596,7 @@
     "frame": "c",
     "distribution": "d",
     "pronominal_class": "maq",
-    "agent_subject": false,
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []

--- a/format.md
+++ b/format.md
@@ -14,6 +14,13 @@ Please insert your fields as you need them (not too much, though) – the format
 * `keywords` - a list of English words that one might search for when trying to find the headword; synonyms of the gloss or of the main words found in the sentential definition
 * `frame` – frame definition, if known; `"variable"` means that the word doesn't have a set frame (possibly anaphoric)
 * `distribution` - a string of the same format as `frame` where each slot type is replaced with either of ‘d’ or ‘n’ (for ‘distributive’ and ‘non-distributive’); `"variable"` – as above
+* `subject` - describes how the subject is constrained. Useful for semantics analysis. One of six string values:
+  * `"event"` is for subjects that are necessarily events (like **bıe**).
+  * `"proposition"` is for subjects that are necessarily propositions (like **guosıa**).
+  * `"individual"` is for verbs whose subjects _can't_ be events or propositions, and so they should subject-share, like **jaı**.
+  * `"agent"` implies `"individual"` and also syntactic ergativity. An example is **koı**.
+  * `"free"` is for verbs whose subjects can be anything, like **gı**. This implies _no_ subject-sharing.
+  * `"shape"` is kinda weird. It's for subjects that have a "shape", like **sao**. I don't know if we want to pretend events have "shapes", but I think it's kind of nice. Then **Koı jí sâo** means I walk and the event is spatio-temporally big. So if people agree with this I will change all the `"shape"`s to `"free"`, otherwise I will change them to `"individual"`.
 * `namesake` – whether this word is the name used to refer to its frametype
 * `notes` – array of strings
 * `examples` – array of objects:

--- a/tools/normalize.js
+++ b/tools/normalize.js
@@ -72,8 +72,7 @@ d = d.map((obj) => {
   ensureField(["keywords"], []);
 
   if (verbyTypes.includes(type)) {
-    ensureField(["frame", "distribution", "pronominal_class"], "");
-    ensureField(["agent_subject"], false);
+    ensureField(["frame", "distribution", "pronominal_class", "subject"], "");
     ensureField(["verb_class", "namesake"]);
     ensureField(["notes", "examples"], []);
     ensureField(["fields"], []);


### PR DESCRIPTION
Mainly with adverbs / subject-sharing in mind:

* `event` and `proposition` are for subjects that are necessarily events (like **bıe**) or propositions (like **guosıa**). I'm taking an event to be a "instantiation at a time and place" of a proposition. So events "occur" and propositions "are the case".
* `individual` is for verbs whose subjects _can't_ be events or propositions, and so they should subject-share in tone 4, like **jaı**.
* `agent` implies `individual` and also syntactic ergativity. An example is **koı**.
* `free` is for verbs whose subjects can be anything, like **gı**. This implies _no_ subject-sharing.
* `shape` is kinda weird. It's for subjects that have a "shape", like **sao**. I don't know if we want to pretend events have "shapes", but I think it's kind of nice. Then **Koı jí sâo** means I walk and the event is spatio-temporally big. So if people agree with this I will change all the `shape`s to `free`, otherwise I will change them to `individual`.