### PR TITLE
Call object-incorporating verbs "predicatizers"

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -8714,7 +8714,7 @@
   },
   {
     "toaq": "jeı",
-    "type": "object incorporating verb",
+    "type": "predicatizer",
     "english": "turns following phrase X into verb: ▯ is X.",
     "gloss": "identical",
     "short": "",
@@ -12254,7 +12254,7 @@
   },
   {
     "toaq": "mea",
-    "type": "object incorporating verb",
+    "type": "predicatizer",
     "english": "turns following phrase X into verb: ▯ is among X.",
     "gloss": "among",
     "short": "",
@@ -14739,7 +14739,7 @@
   },
   {
     "toaq": "po",
-    "type": "object incorporating verb",
+    "type": "predicatizer",
     "english": "turns following phrase X into verb: ▯ is of X; ▯ is associated with X.",
     "gloss": "of",
     "short": "",

--- a/tools/normalize.js
+++ b/tools/normalize.js
@@ -45,7 +45,7 @@ d = d.sort((a, b) => {
 
 const verbyTypes = [
   "predicate",
-  "object incorporating verb",
+  "predicatizer",
   "name verb",
   "name quote",
   "word quote",


### PR DESCRIPTION
As in the Delta refgram: https://toaq.net/refgram/syntax/#predicatizers

Looks like they were called "predicatizer" in Beta, then "object-incorporating verb" [in Gamma](https://toaq.net/gamma/refgram/08/), and now "predicatizer" again.

There's one stray reference in the refgram to **shu** as a predicatizer but I wonder if that's an error? The section about **shu** itself calls it a "single-word quotation verb".