### PR TITLE
add prefix forms for determiners (like ⟨sa-⟩)

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -945,6 +945,16 @@
     "examples": []
   },
   {
+    "toaq": "baq-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with báq (generic; X-kind)",
+    "gloss": "of:GEN",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "baı",
     "type": "predicate",
     "english": "▯ builds/assembles/makes ▯.",
@@ -6311,16 +6321,6 @@
     "fields": []
   },
   {
-    "toaq": "hu-",
-    "type": "prefix",
-    "english": "derives anaphoric pronouns referring to phrases headed by the specified stem",
-    "gloss": "PREV",
-    "short": "",
-    "keywords": [],
-    "notes": [],
-    "examples": []
-  },
-  {
     "toaq": "hupı",
     "type": "predicate",
     "english": "▯ is a fox.",
@@ -6355,6 +6355,16 @@
     "type": "determiner",
     "english": "endophoric; the aforementioned X",
     "gloss": "ENDO",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
+    "toaq": "hu-",
+    "type": "mixed determiner prefix form and pronominalizer",
+    "english": "for verbs: fills object of verb with hú (endophoric; the aforementioned X); for other parts of speech: derives anaphoric pronouns referring to phrases headed by the specified stem",
+    "gloss": "PREV",
     "short": "",
     "keywords": [],
     "notes": [],
@@ -9806,6 +9816,16 @@
     "fields": []
   },
   {
+    "toaq": "ke-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with ké (exophoric; this X (not previously mentioned))",
+    "gloss": "of:EXO",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "keq",
     "type": "predicate",
     "english": "▯ are feces; ▯ is excrement/shit/poo.",
@@ -13103,6 +13123,16 @@
     "fields": []
   },
   {
+    "toaq": "nı-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with ní (demonstrative; this/that X)",
+    "gloss": "of:this",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "nıq",
     "type": "predicate",
     "english": "▯ is new; ▯ is new to ▯.",
@@ -15753,6 +15783,16 @@
     "fields": []
   },
   {
+    "toaq": "sa-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with sá (existential quantifier)",
+    "gloss": "of:some",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "saq",
     "type": "predicate",
     "english": "▯ are three in number.",
@@ -17223,6 +17263,16 @@
     "fields": []
   },
   {
+    "toaq": "sıa-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with sía (zero quantifier)",
+    "gloss": "of:no",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "sıaq",
     "type": "predicate",
     "english": "▯ is to the right of ▯.",
@@ -17953,6 +18003,16 @@
     "examples": []
   },
   {
+    "toaq": "tu-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with tú (singular universal quantifier)",
+    "gloss": "of:each",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "túq",
     "type": "determiner",
     "english": "collective universal quantifier",
@@ -17991,6 +18051,16 @@
     "notes": [],
     "examples": [],
     "fields": []
+  },
+  {
+    "toaq": "tuq-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with túq (collective universal quantifier)",
+    "gloss": "of:all",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
   },
   {
     "toaq": "tuaja",


### PR DESCRIPTION
⟨hu-⟩ is defined as a hybrid prefix. The way I view this grammatically is that there are two prefixes in prefixspace which are homophonous on the surface level – call them ⟨hu-ᵥ⟩ and ⟨hu-⟩ – and ⟨hu-ᵥ⟩ collocates with V complements in the distributed morphology. This would probably require approval from @solpahi but I should mention as a historical note that Loglan did something similar with its suffixes, like the example of [⟨-zi⟩](https://randall-holmes.github.io/Loglan/Dictionary/L-to-E-TDR.html#zi), and at any rate we could always drop that part of the PR or reallocate current ⟨hu-⟩.