### PR TITLE
add prefix forms for determiners (like ⟨tu-⟩)

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -945,6 +945,16 @@
     "examples": []
   },
   {
+    "toaq": "baq-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with báq (generic; X-kind)",
+    "gloss": "of:GEN",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "baı",
     "type": "predicate",
     "english": "▯ builds/assembles/makes ▯.",
@@ -9806,6 +9816,16 @@
     "fields": []
   },
   {
+    "toaq": "ke-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with ké (exophoric; this X (not previously mentioned))",
+    "gloss": "of:EXO",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "keq",
     "type": "predicate",
     "english": "▯ are feces; ▯ is excrement/shit/poo.",
@@ -13103,6 +13123,16 @@
     "fields": []
   },
   {
+    "toaq": "nı-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with ní (demonstrative; this/that X)",
+    "gloss": "of:this",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "nıq",
     "type": "predicate",
     "english": "▯ is new; ▯ is new to ▯.",
@@ -15753,6 +15783,16 @@
     "fields": []
   },
   {
+    "toaq": "sa-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with sá (existential quantifier)",
+    "gloss": "of:some",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "saq",
     "type": "predicate",
     "english": "▯ are three in number.",
@@ -17223,6 +17263,16 @@
     "fields": []
   },
   {
+    "toaq": "sıa-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with sía (zero quantifier)",
+    "gloss": "of:no",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "sıaq",
     "type": "predicate",
     "english": "▯ is to the right of ▯.",
@@ -17953,6 +18003,16 @@
     "examples": []
   },
   {
+    "toaq": "tu-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with tú (singular universal quantifier)",
+    "gloss": "of:each",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
     "toaq": "túq",
     "type": "determiner",
     "english": "collective universal quantifier",
@@ -17991,6 +18051,16 @@
     "notes": [],
     "examples": [],
     "fields": []
+  },
+  {
+    "toaq": "tuq-",
+    "type": "determiner prefix form",
+    "english": "fills object of verb with túq (collective universal quantifier)",
+    "gloss": "of:all",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
   },
   {
     "toaq": "tuaja",


### PR DESCRIPTION
Attested in the refgram (paragraph below [mua47](https://toaq.net/refgram/syntax/#mua47) mentions **tụjoe**); otherwise popular in the wild.