### PR TITLE
make hu- a dual DO-determiner and anaphorizer

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -6311,16 +6311,6 @@
     "fields": []
   },
   {
-    "toaq": "hu-",
-    "type": "prefix",
-    "english": "derives anaphoric pronouns referring to phrases headed by the specified stem",
-    "gloss": "PREV",
-    "short": "",
-    "keywords": [],
-    "notes": [],
-    "examples": []
-  },
-  {
     "toaq": "hupı",
     "type": "predicate",
     "english": "▯ is a fox.",
@@ -6355,6 +6345,16 @@
     "type": "determiner",
     "english": "endophoric; the aforementioned X",
     "gloss": "ENDO",
+    "short": "",
+    "keywords": [],
+    "notes": [],
+    "examples": []
+  },
+  {
+    "toaq": "hu-",
+    "type": "mixed determiner prefix form and pronominalizer",
+    "english": "for verbs: fills object of verb with hú (endophoric; the aforementioned X); for other parts of speech: derives anaphoric pronouns referring to phrases headed by the specified stem",
+    "gloss": "PREV",
     "short": "",
     "keywords": [],
     "notes": [],


### PR DESCRIPTION
⟨hu-⟩ is defined as a hybrid prefix. The way I view this grammatically is that there are two prefixes in prefixspace which are homophonous on the surface level – call them ⟨hu-ᵥ⟩ and ⟨hu-⟩ – and ⟨hu-ᵥ⟩ collocates with V complements in the distributed morphology. This would probably require approval from @solpahi but I should mention as a historical note that Loglan did something similar with its suffixes, like the example of [⟨-zi⟩](https://randall-holmes.github.io/Loglan/Dictionary/L-to-E-TDR.html#zi), and at any rate we could always drop this PR or reallocate current ⟨hu-⟩.