### PR TITLE
Change the animacy class of rıaq

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -15137,7 +15137,7 @@
     "keywords": [],
     "frame": "c 0",
     "distribution": "d d",
-    "pronominal_class": "hoq",
+    "pronominal_class": "maq",
     "subject": "individual",
     "notes": [],
     "examples": [],


### PR DESCRIPTION
Rıaq being abstract feels a bit backwards to me: most rıaq compounds are inanimate, and even the word gua is inanimate.