### PR TITLE
Removing valency polymorphism for ⟪duo⟫, making it exclusively bivalent.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3890,7 +3890,7 @@
   {
     "toaq": "duo",
     "type": "predicate",
-    "english": "▯ lasts/continues; ▯ lasts for time ▯.",
+    "english": "▯ lasts for time ▯.",
     "gloss": "continue",
     "short": "",
     "keywords": [],


### PR DESCRIPTION
The monovalent definition ⟪▯ lasts/continues;⟫ is removed.