### PR TITLE
Addition of ⟪seoqhıe⟫.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -16213,6 +16213,21 @@
     "fields": []
   },
   {
+    "toaq": "seoqhıe",
+    "type": "predicate",
+    "english": "▯ is a member the suborder Caelifera (the grasshoppers in the strict sense).",
+    "gloss": "grasshopper",
+    "short": "",
+    "keywords": [],
+    "frame": "c",
+    "distribution": "d",
+    "pronominal_class": "ho",
+    "subject": "individual",
+    "notes": [],
+    "examples": [],
+    "fields": []
+  },
+  {
     "toaq": "seoqrea",
     "type": "predicate",
     "english": "▯ is a horizon.",


### PR DESCRIPTION
The word was added by Hoemaı to Toadua, so it can rightly be considered official.