### PR TITLE
Removing valency polymorphism for ⟪chuq⟫ and ⟪nuoı⟫, making them excl…

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2427,7 +2427,7 @@
   {
     "toaq": "chuq",
     "type": "predicate",
-    "english": "▯ eats; ▯ eats ▯.",
+    "english": "▯ eats ▯.",
     "gloss": "eat",
     "short": "",
     "keywords": [],
@@ -13610,7 +13610,7 @@
   {
     "toaq": "nuoı",
     "type": "predicate",
-    "english": "▯ chews; ▯ chews ▯; ▯ chews on ▯.",
+    "english": "▯ chews ▯; ▯ chews on ▯.",
     "gloss": "masticate",
     "short": "",
     "keywords": [],


### PR DESCRIPTION
…usively bivalent.