### PR TITLE
Removing valency polymorphism for ⟪paı⟫, making it exclusively bivalent.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -13815,7 +13815,7 @@
   {
     "toaq": "paı",
     "type": "predicate",
-    "english": "▯ is a friend; ▯ is a friend of ▯.",
+    "english": "▯ is a friend of ▯.",
     "gloss": "friend",
     "short": "",
     "keywords": [],


### PR DESCRIPTION
This removes the monovalent meaning ⟪▯ is a friend.⟫.
An alternative solution would be to have ⟪paı⟫ be a subjective predicate like ⟪de⟫, requiring use of ⟪jıe⟫ for explicitly specifying the contextual subjective evaluator, so that ⟪This is a friend of mine⟫ would read as ⟪paı ní jîe jí⟫… I'm not sure this is the best option, but at least it's a possibility…