### PR TITLE
Removing valency polymorphism for ⟪tuo⟫, making it exclusively bivalent.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -19170,7 +19170,7 @@
   {
     "toaq": "tuo",
     "type": "predicate",
-    "english": "▯ swallows; ▯ swallows ▯.",
+    "english": "▯ swallows ▯.",
     "gloss": "swallow",
     "short": "",
     "keywords": [],


### PR DESCRIPTION
Rationale: As per my discussion with Salarua, it's not possible to swallow while swallowing nothing, at the very least you'll swallow air. Therefore, bivalent ⟪tuo⟫ doesn't manifest the *botpi* issue.
As for how to say ⟪swallow⟫ without specifying the object, well, ⟪sạtuo⟫ is an option.