### PR TITLE
Officializes @robintown «roq».

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -15516,14 +15516,14 @@
   {
     "toaq": "roq",
     "type": "predicate",
-    "english": "▯ cries/weeps; ▯ cries tears ▯.",
+    "english": "▯ cries/sobs/weeps.",
     "gloss": "weep",
     "short": "",
     "keywords": [],
     "frame": "c c",
     "distribution": "d d",
     "pronominal_class": "ho",
-    "subject": "agent",
+    "subject": "individual",
     "notes": [],
     "examples": [],
     "fields": []


### PR DESCRIPTION
The bivalent definition goes away and `roq.subject` becomes `I`, aligning with «hıaı» &c.