### PR TITLE
Switches "color" to "colour" in **naraq**.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -12454,7 +12454,7 @@
   {
     "toaq": "naraq",
     "type": "predicate",
-    "english": "▯ is of orange color.",
+    "english": "▯ is of orange colour.",
     "gloss": "orange",
     "short": "",
     "keywords": [],


### PR DESCRIPTION
For consistency— "naraq" is the only word who's definition has the US spelling.